### PR TITLE
feat(deep-clone): new package for deep clone obj/array

### DIFF
--- a/packages/deep-clone/README.md
+++ b/packages/deep-clone/README.md
@@ -1,0 +1,28 @@
+# Deep Clone
+
+Clone deeply nested objects and arrays in JavaScript.
+
+## Installation
+
+```bash
+yarn add @alwatr/deep-clone
+```
+
+## Usage
+
+```typescript
+import deepClone from '@alwatr/deep-clone';
+
+const obj1 = {
+  a: 1,
+  b: {
+    c: 2,
+    d: [3, 4, 5],
+  },
+};
+
+const obj2 = deepClone(obj1);
+
+obj2.b.c = 6;
+console.log(obj1.b.c); // 2
+```

--- a/packages/deep-clone/package.json
+++ b/packages/deep-clone/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@alwatr/deep-clone",
+  "version": "1.0.0",
+  "description": "Clone deeply nested objects and arrays in JavaScript.",
+  "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com>",
+  "keywords": [
+    "deep-clone",
+    "clone",
+    "object",
+    "copy",
+    "typescript",
+    "esm",
+    "alwatr"
+  ],
+  "type": "module",
+  "main": "./dist/main.cjs",
+  "module": "./dist/main.mjs",
+  "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/main.mjs",
+      "require": "./dist/main.cjs",
+      "types": "./dist/main.d.ts"
+    }
+  },
+  "license": "MIT",
+  "files": [
+    "**/*.{d.ts.map,d.ts,js.map,js,html,md,cjs,mjs,cjs.map,mjs.map}"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Alwatr/nanolib",
+    "directory": "packages/deep-clone"
+  },
+  "homepage": "https://github.com/Alwatr/nanolib/tree/next/packages/deep-clone#readme",
+  "bugs": {
+    "url": "https://github.com/Alwatr/nanolib/issues"
+  },
+  "prettier": "@alwatr/prettier-config",
+  "scripts": {
+    "b": "yarn run build",
+    "w": "yarn run watch",
+    "c": "yarn run clean",
+    "cb": "yarn run clean && yarn run build",
+    "d": "yarn run build:es && ALWATR_DEBUG=1 yarn node",
+    "build": "yarn run build:ts & yarn run build:es",
+    "build:es": "nano-build",
+    "build:ts": "tsc --build",
+    "watch": "yarn run watch:ts & yarn run watch:es",
+    "watch:es": "yarn run build:es --watch",
+    "watch:ts": "yarn run build:ts --watch --preserveWatchOutput",
+    "clean": "rm -rfv dist .tsbuildinfo"
+  },
+  "devDependencies": {
+    "@alwatr/nano-build": "workspace:^",
+    "@alwatr/prettier-config": "workspace:^",
+    "@alwatr/tsconfig-base": "workspace:^",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/deep-clone/src/main.ts
+++ b/packages/deep-clone/src/main.ts
@@ -1,0 +1,30 @@
+/**
+ * Clone deeply nested objects and arrays.
+ *
+ * @param obj The object to clone.
+ * @returns A clone of the object.
+ * @example
+ * ```typescript
+ * const obj2 = deepClone(obj1);
+ * ```
+ */
+export function deepClone<T>(obj: T): T;
+
+/**
+ * Clone deeply nested objects and arrays.
+ *
+ * if the object is null or undefined, it returns null.
+ *
+ * @param obj The object to clone.
+ * @returns A clone of the object.
+ * @example
+ * ```typescript
+ * const obj2 = deepClone(obj1);
+ * ```
+ */
+export function deepClone<T>(obj: T | null | undefined): T | null;
+
+export function deepClone<T>(obj: T | null | undefined): T | null {
+  if (obj == null) return null;
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/packages/deep-clone/tsconfig.json
+++ b/packages/deep-clone/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@alwatr/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@alwatr/deep-clone@workspace:packages/deep-clone":
+  version: 0.0.0-use.local
+  resolution: "@alwatr/deep-clone@workspace:packages/deep-clone"
+  dependencies:
+    "@alwatr/nano-build": "workspace:^"
+    "@alwatr/prettier-config": "workspace:^"
+    "@alwatr/tsconfig-base": "workspace:^"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@alwatr/eslint-config@workspace:^, @alwatr/eslint-config@workspace:packages/eslint-config":
   version: 0.0.0-use.local
   resolution: "@alwatr/eslint-config@workspace:packages/eslint-config"


### PR DESCRIPTION
This pull request adds a new package called deep-clone, which allows for deep cloning of nested objects and arrays in JavaScript. The package provides a function called deepClone that takes an object as input and returns a clone of the object. The function handles deeply nested objects and arrays, and also handles null and undefined values. The package includes TypeScript typings and is published under the MIT license.