### PR TITLE
feat(global-scope): Add @alwatr/global-scope package

### DIFF
--- a/packages/global-scope/README.md
+++ b/packages/global-scope/README.md
@@ -10,6 +10,10 @@ yarn add @alwatr/global-scope
 
 ## Usage
 
+### globalScope
+
+Alternative to `globalThis` that works cross-platform.
+
 ```typescript
 import {globalScope} from '@alwatr/global-scope';
 
@@ -21,4 +25,20 @@ globalScope.alwatr = {
 globalScope.setTimeout(() => {
   console.log(globalScope.alwatr.version); // 1.0.0
 }, 1_000);
+```
+
+### sharedScope_
+
+A global variable that can be used to share state across modules without accessible publicly in the global scope.
+
+```typescript
+// module1.ts
+import {sharedScope_} from '@alwatr/global-scope';
+sharedScope_.foo = 'bar';
+```
+
+```typescript
+// module2.ts
+import {sharedScope_} from '@alwatr/global-scope';
+console.log(sharedScope_.foo); // 'bar'
 ```

--- a/packages/global-scope/README.md
+++ b/packages/global-scope/README.md
@@ -1,0 +1,24 @@
+# Global Scope
+
+Cross-platform substitute for globalThis that operates in both Node.js and the browser, providing accurate type definitions and additional global variables to improve debugging.
+
+## Installation
+
+```bash
+yarn add @alwatr/global-scope
+```
+
+## Usage
+
+```typescript
+import {globalScope} from '@alwatr/global-scope';
+
+globalScope.alwatr = {
+  ...globalScope.alwatr,
+  version: '1.0.0',
+};
+
+globalScope.setTimeout(() => {
+  console.log(globalScope.alwatr.version); // 1.0.0
+}, 1_000);
+```

--- a/packages/global-scope/package.json
+++ b/packages/global-scope/package.json
@@ -72,6 +72,7 @@
     "@alwatr/nano-build": "workspace:^",
     "@alwatr/prettier-config": "workspace:^",
     "@alwatr/tsconfig-base": "workspace:^",
+    "@types/node": "^20.10.5",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/global-scope/package.json
+++ b/packages/global-scope/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@alwatr/global-scope",
+  "version": "1.0.0",
+  "description": "Cross-platform substitute for globalThis that operates in both Node.js and the browser, providing accurate type definitions and additional global variables to improve debugging.",
+  "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com>",
+  "keywords": [
+    "global",
+    "globalThis",
+    "global-polyfill",
+    "global-shim",
+    "globalThis-polyfill",
+    "globalThis-shim",
+    "cross-platform",
+    "ECMAScript",
+    "typescript",
+    "javascript",
+    "node",
+    "nodejs",
+    "browser",
+    "esm",
+    "module",
+    "utility",
+    "util",
+    "utils",
+    "nanolib",
+    "alwatr"
+  ],
+  "type": "module",
+  "main": "./dist/main.cjs",
+  "module": "./dist/main.mjs",
+  "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/main.mjs",
+      "require": "./dist/main.cjs",
+      "types": "./dist/main.d.ts"
+    }
+  },
+  "license": "MIT",
+  "files": [
+    "**/*.{js,mjs,cjs,map,d.ts,html,md}",
+    "!demo/**/*"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Alwatr/nanolib",
+    "directory": "packages/global-scope"
+  },
+  "homepage": "https://github.com/Alwatr/nanolib/tree/next/packages/global-scope#readme",
+  "bugs": {
+    "url": "https://github.com/Alwatr/nanolib/issues"
+  },
+  "prettier": "@alwatr/prettier-config",
+  "scripts": {
+    "b": "yarn run build",
+    "w": "yarn run watch",
+    "c": "yarn run clean",
+    "cb": "yarn run clean && yarn run build",
+    "d": "yarn run build:es && ALWATR_DEBUG=1 yarn node",
+    "build": "yarn run build:ts & yarn run build:es",
+    "build:es": "nano-build",
+    "build:ts": "tsc --build",
+    "watch": "yarn run watch:ts & yarn run watch:es",
+    "watch:es": "yarn run build:es --watch",
+    "watch:ts": "yarn run build:ts --watch --preserveWatchOutput",
+    "clean": "rm -rfv dist .tsbuildinfo"
+  },
+  "devDependencies": {
+    "@alwatr/nano-build": "workspace:^",
+    "@alwatr/prettier-config": "workspace:^",
+    "@alwatr/tsconfig-base": "workspace:^",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/global-scope/src/main.ts
+++ b/packages/global-scope/src/main.ts
@@ -1,8 +1,40 @@
 /**
  * Alternative to `globalThis` that works cross-platform.
+ *
+ * @example
+ * ```typescript
+ * globalScope.alwatr = {
+ *  ...globalScope.alwatr,
+ *  foo: 'bar',
+ * }
+ * ```
  */
-export const globalScope =
+export const globalScope: typeof globalThis =
   (typeof globalThis === 'object' && globalThis) ||
-  ('object' === typeof window && window) ||
-  ('object' === typeof global && global) ||
+  (typeof window === 'object' && window) ||
+  (typeof global === 'object' && global) ||
   self;
+
+/**
+ * A global variable that can be used to share state across modules without accessible publicly in the global scope.
+ *
+ * @example
+ * ```typescript
+ * // module1.ts
+ * shareScope_.foo = 'bar';
+ *
+ * // module2.ts
+ * console.log(shareScope_.foo); // 'bar'
+ * ```
+ */
+export const sharedScope_: Record<string, unknown> = {};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __shared_scope_defined__: boolean;
+}
+
+if (globalScope.__shared_scope_defined__ !== undefined) {
+  throw new Error('global_scope_module_duplicated');
+}
+globalScope.__shared_scope_defined__ = true;

--- a/packages/global-scope/src/main.ts
+++ b/packages/global-scope/src/main.ts
@@ -1,0 +1,8 @@
+/**
+ * Alternative to `globalThis` that works cross-platform.
+ */
+export const globalScope =
+  (typeof globalThis === 'object' && globalThis) ||
+  ('object' === typeof window && window) ||
+  ('object' === typeof global && global) ||
+  self;

--- a/packages/global-scope/tsconfig.json
+++ b/packages/global-scope/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@alwatr/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,7 @@ __metadata:
     "@alwatr/nano-build": "workspace:^"
     "@alwatr/prettier-config": "workspace:^"
     "@alwatr/tsconfig-base": "workspace:^"
+    "@types/node": "npm:^20.10.5"
     typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
@@ -1055,6 +1056,15 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^20.10.5":
+  version: 20.10.5
+  resolution: "@types/node@npm:20.10.5"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: be30609aae0bfe492097815f166ccc07f465220cb604647fa4e5ec05a1d16c012a41b82b5f11ecfe2485cbb479d4d20384b95b809ca0bcff6d94d5bbafa645bb
   languageName: node
   linkType: hard
 
@@ -5691,6 +5701,13 @@ __metadata:
     has-symbols: "npm:^1.0.3"
     which-boxed-primitive: "npm:^1.0.2"
   checksum: 81ca2e81134167cc8f75fa79fbcc8a94379d6c61de67090986a2273850989dd3bae8440c163121b77434b68263e34787a675cbdcb34bb2f764c6b9c843a11b66
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@alwatr/global-scope@workspace:packages/global-scope":
+  version: 0.0.0-use.local
+  resolution: "@alwatr/global-scope@workspace:packages/global-scope"
+  dependencies:
+    "@alwatr/nano-build": "workspace:^"
+    "@alwatr/prettier-config": "workspace:^"
+    "@alwatr/tsconfig-base": "workspace:^"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@alwatr/nano-build@workspace:^, @alwatr/nano-build@workspace:packages/nano-build":
   version: 0.0.0-use.local
   resolution: "@alwatr/nano-build@workspace:packages/nano-build"


### PR DESCRIPTION
This pull request adds the @alwatr/global-scope package, which is a cross-platform substitute for globalThis that operates in both Node.js and the browser. It provides accurate type definitions and additional global variables to improve debugging.