### PR TITLE
feat(platform-info): new package for detect the current platform

### DIFF
--- a/packages/platform-info/README.md
+++ b/packages/platform-info/README.md
@@ -1,0 +1,36 @@
+# Platform Info
+
+This module provides a way to detect the current platform where the script is running. It defines a constant `platformInfo` which holds the information about the current platform.
+
+## PlatformInfo Object
+
+The `platformInfo` constant object has the following properties:
+
+- `name`: The name of the current platform. It can be 'browser', 'node', 'semi-node', or 'unknown'.
+- `development`: A boolean indicating whether the NODE_ENV environment variable is not set to `production` or in browser location.hostname is `localhost` or `127.xxx`.
+- `isNode`: A boolean indicating whether the current platform is node.js.
+- `isBrowser`: A boolean indicating whether the current platform is a browser.
+- `isDeno`: A boolean indicating whether the current platform is Deno.
+- `isNw`: A boolean indicating whether the current platform is nw.js.
+- `isElectron`: A boolean indicating whether the current platform is Electron.
+
+## Development Mode Detection
+
+The code also checks whether the script is running in development mode. If the script is running in a browser, it checks if the hostname is 'localhost' or `127.xxx`. If the script is running in a 'semi-node' environment, it checks if the NODE_ENV environment variable is not set to 'production'. The result is stored in the `development` property of the `platformInfo` object.
+
+## Installation
+
+```bash
+yarn add @alwatr/platform-info
+```
+
+## Usage
+
+```typescript
+import {platformInfo} from '@alwatr/platform-info';
+
+console.log(platformInfo.name); // 'browser' | 'node' | 'semi-node' | 'unknown'
+console.log(platformInfo.development); // true | false
+console.log(platformInfo.isNode); // true | false
+console.log(platformInfo.isBrowser); // true | false
+```

--- a/packages/platform-info/package.json
+++ b/packages/platform-info/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@alwatr/platform-info",
+  "version": "1.0.0",
+  "description": "",
+  "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com>",
+  "keywords": [
+    "platform",
+    "cross-platform",
+    "ECMAScript",
+    "typescript",
+    "javascript",
+    "node",
+    "nodejs",
+    "browser",
+    "esm",
+    "module",
+    "utility",
+    "util",
+    "utils",
+    "nanolib",
+    "alwatr"
+  ],
+  "type": "module",
+  "main": "./dist/main.cjs",
+  "module": "./dist/main.mjs",
+  "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/main.mjs",
+      "require": "./dist/main.cjs",
+      "types": "./dist/main.d.ts"
+    }
+  },
+  "license": "MIT",
+  "files": [
+    "**/*.{js,mjs,cjs,map,d.ts,html,md}",
+    "!demo/**/*"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Alwatr/nanolib",
+    "directory": "packages/platform-info"
+  },
+  "homepage": "https://github.com/Alwatr/nanolib/tree/next/packages/platform-info#readme",
+  "bugs": {
+    "url": "https://github.com/Alwatr/nanolib/issues"
+  },
+  "prettier": "@alwatr/prettier-config",
+  "scripts": {
+    "b": "yarn run build",
+    "w": "yarn run watch",
+    "c": "yarn run clean",
+    "cb": "yarn run clean && yarn run build",
+    "d": "yarn run build:es && ALWATR_DEBUG=1 yarn node",
+    "build": "yarn run build:ts & yarn run build:es",
+    "build:es": "nano-build",
+    "build:ts": "tsc --build",
+    "watch": "yarn run watch:ts & yarn run watch:es",
+    "watch:es": "yarn run build:es --watch",
+    "watch:ts": "yarn run build:ts --watch --preserveWatchOutput",
+    "clean": "rm -rfv dist .tsbuildinfo"
+  },
+  "devDependencies": {
+    "@alwatr/nano-build": "workspace:^",
+    "@alwatr/prettier-config": "workspace:^",
+    "@alwatr/tsconfig-base": "workspace:^",
+    "@types/node": "^20.10.5",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/platform-info/src/main.ts
+++ b/packages/platform-info/src/main.ts
@@ -1,0 +1,90 @@
+/**
+ * Represents information about the current platform.
+ */
+interface PlatformInfo {
+  /**
+   * The current platform name.
+   * - `browser` for browsers.
+   * - `node` for node.js environments.
+   * - `semi-node` for node.js like environments such as nw.js, deno, etc.
+   * - `unknown` for unknown environments.
+   */
+  name: 'browser' | 'node' | 'semi-node' | 'unknown';
+
+  /**
+   * Whether the NODE_ENV environment variable is not `production` or in browser location.hostname is `localhost`.
+   */
+  development: boolean;
+
+  /**
+   * Whether the current platform is node.js.
+   */
+  isNode: boolean;
+
+  /**
+   * Whether the current platform is a browser.
+   */
+  isBrowser: boolean;
+
+  /**
+   * Whether the current platform is deno.
+   */
+  isDeno: boolean;
+
+  /**
+   * Whether the current platform is nw.js.
+   */
+  isNw: boolean;
+
+  /**
+   * Whether the current platform is electron.
+   */
+  isElectron: boolean;
+}
+
+/**
+ * Represents information about the current platform.
+ */
+const platformInfo: PlatformInfo = {
+  name: 'unknown',
+  development: false,
+  isNode: false,
+  isBrowser: false,
+  isDeno: false,
+  isNw: false,
+  isElectron: false,
+};
+
+if (typeof window === 'object' && typeof document === 'object' && document.nodeType === Node.DOCUMENT_NODE) {
+  platformInfo.name = 'browser';
+  platformInfo.isBrowser = true;
+}
+else if (process.versions?.node != null) {
+  platformInfo.name = 'node';
+  platformInfo.isNode = true;
+}
+else if (typeof process === 'object') {
+  platformInfo.name = 'semi-node';
+
+  if (process.versions?.electron != null) {
+    platformInfo.isElectron = true;
+  }
+  // @ts-expect-error - Cannot find name 'nw'
+  else if (typeof nw !== 'undefined') {
+    platformInfo.isNw = true;
+  }
+}
+
+// other platforms
+// @ts-expect-error - Cannot find name 'Deno'
+if (typeof Deno !== 'undefined') {
+  platformInfo.isDeno = true;
+}
+
+// development
+if (platformInfo.isBrowser) {
+  platformInfo.development = location.hostname === 'localhost' || location.hostname.indexOf('127.') === 0;
+}
+else if (platformInfo.name === 'semi-node') {
+  platformInfo.development = process.env.NODE_ENV !== 'production';
+}

--- a/packages/platform-info/tsconfig.json
+++ b/packages/platform-info/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@alwatr/tsconfig-base/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@alwatr/platform-info@workspace:packages/platform-info":
+  version: 0.0.0-use.local
+  resolution: "@alwatr/platform-info@workspace:packages/platform-info"
+  dependencies:
+    "@alwatr/nano-build": "workspace:^"
+    "@alwatr/prettier-config": "workspace:^"
+    "@alwatr/tsconfig-base": "workspace:^"
+    "@types/node": "npm:^20.10.5"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@alwatr/prettier-config@workspace:^, @alwatr/prettier-config@workspace:packages/prettier-config":
   version: 0.0.0-use.local
   resolution: "@alwatr/prettier-config@workspace:packages/prettier-config"


### PR DESCRIPTION
This pull request adds a new package called platform-info. This package provides a way to detect the current platform where the script is running. It includes an object called `platformInfo` with properties such as `name`, `development`, `isNode`, `isBrowser`, `isDeno`, `isNw`, and `isElectron`. The package also includes installation instructions and usage examples.