### PR TITLE
feat(nano-build): Add presets for module bundling

### DIFF
--- a/packages/nano-build/README.md
+++ b/packages/nano-build/README.md
@@ -103,9 +103,44 @@ Add 'nano-build' field to your `package.json` for overwriting configuration:
 
 ### `--preset=module`
 
+Builds and bundle a single entry point.
+
 ```js
 {
   ...defaultPreset,
+  entryPoints: ['src/main.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  cjs: true,
+  packages: 'external',
+}
+```
+
+### `--preset=module2`
+
+Builds and bundles multiple entry points in root of `src` directory.
+
+```js
+{
+  ...defaultPreset,
+  entryPoints: ['src/*.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  cjs: true,
+  packages: 'external',
+}
+```
+
+### `--preset=module3`
+
+Builds multiple entry points in `src` directory without bundling.
+
+```js
+{
+  entryPoints: ['src/**/*.ts'],
+  bundle: false,
   platform: 'node',
   format: 'esm',
   cjs: true,

--- a/packages/nano-build/nano-build.cjs
+++ b/packages/nano-build/nano-build.cjs
@@ -63,10 +63,27 @@ const developmentOptions = {
 const presetRecord = {
   default: {},
   module: {
+    entryPoints: ['src/main.ts'],
+    bundle: true,
     platform: 'node',
     format: 'esm',
     cjs: true,
-    // mangleProps: '__$',
+    packages: 'external',
+  },
+  module2: {
+    entryPoints: ['src/*.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    cjs: true,
+    packages: 'external',
+  },
+  module3: {
+    entryPoints: ['src/**/*.ts'],
+    bundle: false,
+    platform: 'node',
+    format: 'esm',
+    cjs: true,
     packages: 'external',
   },
   pwa: {


### PR DESCRIPTION
This commit adds three new presets to the nano-build package: `module`, `module2`, and `module3`. These presets allow for different configurations when building and bundling multiple entry points in the `src` directory. The `module` preset bundles a single entry point (`src/main.ts`), while the `module2` preset bundles multiple entry points in the root of the `src` directory (`src/*.ts`). The `module3` preset builds multiple entry points in the `src` directory without bundling. These presets provide flexibility and customization options for developers using the nano-build package.
