### PR TITLE
Update TypeScript target to ESNext and refine compiler options

### DIFF
--- a/packages/tsconfig-base/tsconfig.json
+++ b/packages/tsconfig-base/tsconfig.json
@@ -16,7 +16,7 @@
     // "outFile": "./",
     // "outDir": "./",
     // "rootDir": "./src",
-    // "composite": true,
+    "composite": true,
     // "tsBuildInfoFile": ".tsbuildinfo",
     // "removeComments": true,
     // "noEmit": true,

--- a/packages/tsconfig-base/tsconfig.json
+++ b/packages/tsconfig-base/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     /* Basic Options */
     "incremental": true,
-    "target": "ES2020",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ESNext", "DOM"],
@@ -16,13 +16,13 @@
     // "outFile": "./",
     // "outDir": "./",
     // "rootDir": "./src",
-    "composite": true,
+    // "composite": true,
     // "tsBuildInfoFile": ".tsbuildinfo",
     // "removeComments": true,
     // "noEmit": true,
     // "emitDeclarationOnly": true,
     // "importHelpers": true,
-    // "noEmitHelpers": true,
+    "noEmitHelpers": true,
     // "downlevelIteration": true,
     "isolatedModules": true, // need for esbuild
     "pretty": true,


### PR DESCRIPTION
Change the TypeScript target to ESNext to leverage modern JavaScript features and refine compiler options, including enabling `noEmitHelpers`, which may impact build outputs. This change introduces a breaking change.