### PR TITLE
Revamp delay module with new API and improved functionality

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,5 @@
 *.mjs
 *.cjs
 *.d.ts
-/demo/es-bench/
-/uniquely/flight-finder-pwa
 node_modules
 _data

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,8 @@
     "flatomise",
     "Jsonifiable",
     "Jsonify",
+    "Macrotask",
+    "Microtask",
     "Mihandoost",
     "nanolib",
     "outdir",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "conventional-changelog-conventionalcommits": "9.1.0",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "conventional-commits-filter": "^5.0.0",
     "eslint": "^8.57.1",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/packages/delay/README.md
+++ b/packages/delay/README.md
@@ -1,106 +1,109 @@
 # @alwatr/delay
 
-`@alwatr/delay` offers a collection of utility functions to handle asynchronous execution flow effectively. It allows you to pause your code until specific conditions are met or certain events occur. This functionality aids in managing complex asynchronous scenarios and crafting intricate flows with ease. The functions can be used independently or combined for robust control over asynchronous operations.
+A robust and lightweight utility library for managing asynchronous operations in JavaScript and TypeScript. `@alwatr/delay` provides a collection of promise-based functions to pause execution until specific conditions are met, such as timeouts, animation frames, idle callbacks, or DOM events. This helps create clean, readable, and predictable asynchronous code.
 
 ## Installation
 
 ```bash
+# Using npm
 npm install @alwatr/delay
-```
 
-```bash
+# Using yarn
 yarn add @alwatr/delay
 ```
 
 ## Usage
 
-Each function within `@alwatr/delay` returns a Promise that resolves when the specified waiting condition is met. Here's a breakdown of the available functions:
+All functions are available under the `delay` object and return a `Promise`. You can use them with `async/await` for clean and linear code flow.
 
-- **waitForTimeout(duration: number): Promise<void>**
+```typescript
+import {delay} from '@alwatr/delay';
 
-  - Waits for a specified duration (in milliseconds) before resolving.
-  - Example:
+async function main() {
+  console.log('Waiting for 1 second...');
+  await delay.by('1s');
+  console.log('Done.');
+}
+```
 
-    ```typescript
-    import {waitForTimeout} from '@alwatr/delay';
+### API Reference
 
-    await waitForTimeout(1000); // Waits for 1 second
-    ```
+- **`delay.by(duration: Duration): Promise<void>`**
 
-- **waitForAnimationFrame(): Promise<DOMHighResTimeStamp>**
+  Pauses execution for a specified duration. The duration can be a number (in milliseconds) or a string (e.g., `'2s'`, `'500ms'`).
 
-  - Pauses execution until the next animation frame is scheduled, resolving with the current timestamp.
-  - Useful for synchronizing UI updates with browser rendering.
-  - Example:
+  ```typescript
+  await delay.by(2000); // Waits for 2 seconds
+  await delay.by('5m'); // Waits for 5 minutes
+  ```
 
-    ```typescript
-    import {waitForAnimationFrame} from '@alwatr/delay';
+- **`delay.animationFrame(): Promise<DOMHighResTimeStamp>`**
 
-    await waitForAnimationFrame(); // Waits for next animation frame
-    ```
+  Resolves at the beginning of the next browser animation frame. Useful for synchronizing animations and DOM updates with the browser's rendering cycle to avoid layout thrashing.
 
-- **waitForIdle(timeout?: number): Promise<IdleDeadline>**
+  ```typescript
+  const timestamp = await delay.animationFrame();
+  console.log(`Rendering next frame at ${timestamp}`);
+  // Perform DOM updates here
+  ```
 
-  - Waits for the next idle period (when the browser is not busy), resolving with an `IdleDeadline` object.
-  - Optionally accepts a timeout value (in milliseconds) for maximum waiting time.
-  - Ideal for executing tasks that don't impact user experience.
-  - Example:
+- **`delay.idleCallback(options?: IdleRequestOptions): Promise<IdleDeadline>`**
 
-    ```typescript
-    import {waitForIdle} from '@alwatr/delay';
+  Resolves when the browser's event loop is idle. Ideal for deferring non-critical background tasks to avoid impacting user experience.
 
-    await waitForIdle(); // Waits for next idle period
-    ```
+  ```typescript
+  const deadline = await delay.idleCallback({timeout: 1000});
+  if (!deadline.didTimeout) {
+    console.log('Running background task during idle time.');
+  }
+  ```
 
-- **waitForDomEvent<T extends keyof HTMLElementEventMap>(element: HTMLElement, eventName: T): Promise<HTMLElementEventMap[T]>**
+- **`delay.domEvent<T extends keyof HTMLElementEventMap>(...): Promise<HTMLElementEventMap[T]>`**
 
-  - Pauses execution until a specific DOM event is triggered on a provided element, resolving with the event object.
-  - Example:
+  Waits for a specific DOM event to be dispatched on an `HTMLElement`.
 
-    ```typescript
-    import {waitForDomEvent} from '@alwatr/delay';
+  ```typescript
+  const button = document.getElementById('my-button');
+  if (button) {
+    const event = await delay.domEvent(button, 'click');
+    console.log('Button was clicked!', event);
+  }
+  ```
 
-    const button = document.getElementById('myButton');
-    await waitForDomEvent(button, 'click'); // Waits for click event on button
-    ```
+- **`delay.event(target: EventTarget, eventName: string, ...): Promise<Event>`**
 
-- **waitForEvent(target: HasAddEventListener, eventName: string): Promise<Event>**
+  A more generic version of `domEvent`. Waits for any event on any `EventTarget` (e.g., `window`, `document`, or custom event emitters).
 
-  - More generic version of `waitForDomEvent`, allowing waiting for any event on any object with an `addEventListener` method.
-  - Example:
+  ```typescript
+  console.log('Waiting for window resize...');
+  await delay.event(window, 'resize');
+  console.log('Window was resized!');
+  ```
 
-    ```typescript
-    import {waitForEvent} from '@alwatr/delay';
+- **`delay.nextMacrotask(): Promise<void>`**
 
-    const server = http.createServer();
-    await waitForEvent(server, 'request'); // Waits for request event on server
-    ```
+  Schedules a macrotask to run in the next cycle of the event loop. This is useful for yielding control back to the browser, allowing it to handle rendering and other user-facing tasks. Implemented with `setTimeout(..., 0)`.
 
-- **waitForImmediate(): Promise<void>**
+  ```typescript
+  console.log('A');
+  await delay.nextMacrotask();
+  console.log('B'); // This will log after 'A' and after the browser has had a chance to breathe.
+  ```
 
-  - Executes the next task in the microtask queue immediately after the current task finishes.
-  - Example:
+- **`delay.nextMicrotask(): Promise<void>`**
 
-    ```typescript
-    import {waitForImmediate} from '@alwatr/delay';
+  Queues a microtask to be executed immediately after the current task completes, before the event loop proceeds to the next macrotask. Useful for scheduling work that needs to happen synchronously after an operation but without blocking the main thread.
 
-    await waitForImmediate(); // Executes next microtask
-    ```
-
-- **waitForMicrotask(): Promise<void>**
-
-  - Similar to `waitForImmediate`, but waits specifically for the next microtask queue.
-  - Example:
-
-    ```typescript
-    import {waitForMicrotask} from '@alwatr/delay';
-
-    await waitForMicrotask(); // Waits for next microtask queue
-    ```
+  ```typescript
+  console.log('A');
+  Promise.resolve().then(() => console.log('C'));
+  await delay.nextMicrotask();
+  console.log('B'); // Logs A, C, B
+  ```
 
 ## Contributing
 
-We welcome contributions to improve this package! Feel free to open bug reports, suggest new features, or submit pull requests following our [contribution guidelines](https://github.com/Alwatr/.github/blob/next/CONTRIBUTING.md).
+Contributions are welcome\! Please feel free to open an issue or submit a pull request. Read our [contribution guidelines](https://github.com/Alwatr/.github/blob/next/CONTRIBUTING.md) to get started.
 
 ## Sponsors
 

--- a/packages/delay/README.md
+++ b/packages/delay/README.md
@@ -70,7 +70,7 @@ async function main() {
   }
   ```
 
-- **`delay.event(target: EventTarget, eventName: string, ...): Promise<Event>`**
+- **`delay.event(target: EventTarget, eventName: string, options?: AddEventListenerOptions): Promise<Event>`**
 
   A more generic version of `domEvent`. Waits for any event on any `EventTarget` (e.g., `window`, `document`, or custom event emitters).
 

--- a/packages/delay/README.md
+++ b/packages/delay/README.md
@@ -58,7 +58,7 @@ async function main() {
   }
   ```
 
-- **`delay.domEvent<T extends keyof HTMLElementEventMap>(...): Promise<HTMLElementEventMap[T]>`**
+- **`delay.domEvent<T extends keyof HTMLElementEventMap>(element: HTMLElement, eventName: T, options?: AddEventListenerOptions): Promise<HTMLElementEventMap[T]>`**
 
   Waits for a specific DOM event to be dispatched on an `HTMLElement`.
 

--- a/packages/delay/src/main.ts
+++ b/packages/delay/src/main.ts
@@ -3,6 +3,8 @@ import {parseDuration, type Duration} from '@alwatr/parse-duration';
 
 import {requestAnimationFrame, requestIdleCallback} from './polyfill.js';
 
+export {requestAnimationFrame, requestIdleCallback};
+
 __dev_mode__: packageTracer.add(__package_name__, __package_version__);
 
 /**

--- a/packages/delay/src/main.ts
+++ b/packages/delay/src/main.ts
@@ -1,139 +1,136 @@
 import {packageTracer} from '@alwatr/package-tracer';
 import {parseDuration, type Duration} from '@alwatr/parse-duration';
 
-__dev_mode__: packageTracer.add(__package_name__, __package_version__);
-
 import {requestAnimationFrame, requestIdleCallback} from './polyfill.js';
+
+__dev_mode__: packageTracer.add(__package_name__, __package_version__);
 
 /**
  * A utility module to help manage asynchronous operations and waiting for events or timeouts.
  */
 export const delay = {
   /**
-   * Delays execution for a specified duration (in milliseconds).
+   * Pauses execution for a specified duration.
    *
-   * @param duration - The duration to wait (in milliseconds). Use `0` to yield control to the event loop.
+   * @param duration The duration to wait. Can be a number in milliseconds or a string like '2s', '100ms'.
    * @returns A Promise that resolves after the specified duration.
    *
    * @example
    * ```typescript
    * await delay.by('1m'); // Wait for 1 minute
+   * await delay.by('2s'); // Wait for 2 seconds
    * ```
    */
-  by: (duration: Duration): Promise<void> =>
-    new Promise((resolve) => setTimeout(resolve, parseDuration(duration))),
+  by: (duration: Duration): Promise<void> => new Promise((resolve) => setTimeout(resolve, parseDuration(duration))),
 
   /**
-   * Delays execution until the next animation frame.
+   * Pauses execution until the next animation frame.
    *
-   * @returns A Promise that resolves with the current timestamp when the next animation frame is fired.
+   * @returns A Promise that resolves with the high-resolution timestamp of the next animation frame.
    *
    * @example
    * ```typescript
-   * const timestamp = await delay.untilNextAnimationFrame();
+   * const timestamp = await delay.animationFrame();
+   * console.log(`Next frame at ${timestamp}`);
    * ```
    */
-  untilNextAnimationFrame: (): Promise<DOMHighResTimeStamp> =>
-    new Promise((resolve) => requestAnimationFrame(resolve)),
+  animationFrame: (): Promise<DOMHighResTimeStamp> => new Promise((resolve) => requestAnimationFrame(resolve)),
 
   /**
-   * Delays execution until the browser's idle period or the specified timeout.
+   * Pauses execution until the browser is idle.
    *
-   * @param timeout - Optional timeout (in milliseconds) for the idle callback.
-   * @returns A Promise that resolves with the IdleDeadline object when the browser is idle or the timeout is reached.
+   * @param timeout An optional maximum duration to wait.
+   * @returns A Promise that resolves with an `IdleDeadline` object.
    *
    * @example
    * ```typescript
-   * const deadline = await delay.untilIdle();
+   * const deadline = await delay.idleCallback({ timeout: 2000 });
+   * if (deadline.didTimeout) {
+   * console.log('Idle callback timed out.');
+   * }
    * ```
    */
-  untilIdle: (timeout?: Duration): Promise<IdleDeadline> =>
-    new Promise((resolve) => requestIdleCallback(resolve, timeout === undefined ? undefined : {
-      timeout: parseDuration(timeout)
-    })),
+  idleCallback: (options?: IdleRequestOptions): Promise<IdleDeadline> => new Promise((resolve) => requestIdleCallback(resolve, options)),
 
   /**
-   * Delays execution until a specific DOM event occurs on an HTMLElement.
+   * Pauses execution until a specific DOM event is dispatched on an element.
    *
-   * @param element - The HTMLElement to listen for the event on.
-   * @param eventName - The name of the DOM event to wait for.
-   * @template T The event map type.
-   * @returns A Promise that resolves with the event object when the specified event occurs.
+   * @param element The HTMLElement to listen on.
+   * @param eventName The name of the event to wait for.
+   * @param options Optional event listener options.
+   * @template T The event map type for the element.
+   * @returns A Promise that resolves with the triggered event object.
    *
    * @example
    * ```typescript
-   * const clickEvent = await delay.untilDomEvent(document.body, 'click');
+   * const button = document.getElementById('my-button');
+   * if (button) {
+   * const clickEvent = await delay.domEvent(button, 'click');
+   * console.log('Button clicked!', clickEvent);
+   * }
    * ```
    */
-  untilDomEvent: <T extends keyof HTMLElementEventMap>(
+  domEvent: <T extends keyof HTMLElementEventMap>(
     element: HTMLElement,
-    eventName: T
+    eventName: T,
+    options: AddEventListenerOptions = {passive: true},
   ): Promise<HTMLElementEventMap[T]> =>
     new Promise((resolve) =>
-      element.addEventListener(eventName, resolve, { once: true, passive: true })
+      element.addEventListener(eventName, resolve, {
+        ...options,
+        once: true,
+      }),
     ),
 
   /**
-   * Delays execution until a specific event occurs on an object with an `addEventListener` method.
+   * Pauses execution until a specific event is dispatched on any event target.
    *
-   * @param target - The target object to listen for the event on.
-   * @param eventName - The name of the event to wait for.
-   * @returns A Promise that resolves with the event object when the specified event occurs.
+   * @param target The event target (e.g., window, document, or a custom event emitter).
+   * @param eventName The name of the event to wait for.
+   * @param options Optional event listener options.
+   * @returns A Promise that resolves with the triggered event object.
    *
    * @example
    * ```typescript
-   * const server = http.createServer();
-   * const requestEvent = await delay.untilEvent(server, 'request');
+   * const resizeEvent = await delay.event(window, 'resize');
+   * console.log('Window resized:', resizeEvent);
    * ```
    */
-  untilEvent: (target: HasAddEventListener, eventName: string): Promise<Event> =>
+  event: (target: EventTarget, eventName: string, options: AddEventListenerOptions = {passive: true}): Promise<Event> =>
     new Promise((resolve) =>
-      target.addEventListener(eventName, resolve, { once: true, passive: true })
+      target.addEventListener(eventName, resolve, {
+        ...options,
+        once: true,
+      }),
     ),
 
   /**
-   * Yields control to the event loop immediately.
+   * Schedules a macrotask to run after the current event loop task completes.
+   * Uses `setTimeout(..., 0)`.
    *
-   * Uses `setImmediate` if available, falls back to `queueMicrotask`, and then to `setTimeout(0)`.
-   *
-   * @returns A Promise that resolves immediately after yielding control to the event loop.
+   * @returns A Promise that resolves when the macrotask is executed.
    *
    * @example
    * ```typescript
-   * await delay.immediate();
+   * console.log('Start');
+   * await delay.nextMacrotask();
+   * console.log('End - after current task');
    * ```
    */
-  immediate: (): Promise<void> => {
-    if (typeof setImmediate !== 'function') {
-      if (typeof queueMicrotask === 'function') {
-        return delay.nextMicrotask();
-      }
-
-      // else
-      return delay.by(0);
-    }
-    return new Promise((resolve) => setImmediate(resolve));
-  },
+  nextMacrotask: (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0)),
 
   /**
-   * Delays execution until the next microtask queue is empty
+   * Queues a microtask to run after the current task completes but before the next macrotask.
    *
-   * @returns A Promise that resolves when the next microtask queue is empty.
+   * @returns A Promise that resolves when the microtask is executed.
    *
    * @example
    * ```typescript
+   * console.log('Start');
    * await delay.nextMicrotask();
+   * console.log('End - immediately after current task');
    * ```
    */
-  nextMicrotask: (): Promise<void> => {
-    if (typeof queueMicrotask !== 'function') {
-      if (typeof setImmediate === 'function') {
-        return delay.immediate();
-      }
-
-      // else
-      return delay.by(0);
-    }
-    return new Promise((resolve) => queueMicrotask(resolve));
-  },
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  nextMicrotask: (): Promise<void> => Promise.resolve().then(() => {}),
 } as const;

--- a/packages/delay/src/polyfill.ts
+++ b/packages/delay/src/polyfill.ts
@@ -1,19 +1,43 @@
-import {getGlobalThis, type GlobalThis} from '@alwatr/global-this';
+import {getGlobalThis} from '@alwatr/global-this';
 
-export const win = /* #__PURE__ */ getGlobalThis<DictionaryOpt<unknown>>();
+export const global_ = /* #__PURE__ */ getGlobalThis<DictionaryOpt<unknown>>();
 
-// prettier-ignore
-const requestAnimationFrameFallback =
-  (callback: FrameRequestCallback): ReturnType<typeof setTimeout> =>
-    setTimeout(() => callback(Date.now()), 1000 / 60);
+/**
+ * Ensures compatibility for `requestAnimationFrame` by using the native API
+ * available in `globalThis`. If it's not available, it falls back to a `setTimeout`
+ * call that aims for a 60 frames per second refresh rate.
+ *
+ * @param callback The function to call when it's time to update your animation for the next repaint.
+ * @returns A long integer value, the request ID, that uniquely identifies the entry in the callback list.
+ */
+export const requestAnimationFrame: (callback: FrameRequestCallback) => number =
+  global_.requestAnimationFrame?.bind(global_) ??
+  ((callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 1000 / 60));
 
-export const requestAnimationFrame: GlobalThis['requestAnimationFrame'] = /* #__PURE__ */ (() =>
-  win.requestAnimationFrame || win.webkitRequestAnimationFrame || win.mozRequestAnimationFrame || requestAnimationFrameFallback)();
-
-// prettier-ignore
-const requestIdleCallbackFallback =
-  (callback: () => void, options?: IdleRequestOptions): ReturnType<typeof setTimeout> =>
-    setTimeout(callback, options?.timeout ?? 2000);
-
-export const requestIdleCallback: GlobalThis['requestIdleCallback'] = /* #__PURE__ */ (() =>
-  win.requestIdleCallback || win.webkitRequestIdleCallback || win.mozRequestIdleCallback || requestIdleCallbackFallback)();
+/**
+ * Ensures compatibility for `requestIdleCallback` by using the native API.
+ * If unavailable, it falls back to a `setTimeout` that executes the callback
+ * after a short delay, providing a mock `IdleDeadline` object.
+ *
+ * The mock `IdleDeadline` gives the task a 50ms budget to run.
+ *
+ * @param callback A reference to a function that should be called in the near future, when the event loop is idle.
+ * @param options An optional object with configuration parameters.
+ * @returns An ID which can be used to cancel the callback by calling `cancelIdleCallback()`.
+ */
+export const requestIdleCallback: (callback: (deadline: IdleDeadline) => void, options?: IdleRequestOptions) => number =
+  global_.requestIdleCallback?.bind(global_) ??
+  ((
+    callback: (deadline: IdleDeadline) => void,
+    // options is not used in the fallback but kept for API consistency
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: IdleRequestOptions,
+  ) => {
+    const startTime = Date.now();
+    return setTimeout(() => {
+      callback({
+        didTimeout: !!options?.timeout,
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - startTime)),
+      });
+    }, options?.timeout ?? 20);
+  });

--- a/packages/delay/src/polyfill.ts
+++ b/packages/delay/src/polyfill.ts
@@ -1,6 +1,6 @@
 import {getGlobalThis} from '@alwatr/global-this';
 
-export const global_ = /* #__PURE__ */ getGlobalThis<DictionaryOpt<unknown>>();
+const globalThis = /* #__PURE__ */ getGlobalThis<DictionaryOpt<unknown>>();
 
 /**
  * Ensures compatibility for `requestAnimationFrame` by using the native API
@@ -11,8 +11,8 @@ export const global_ = /* #__PURE__ */ getGlobalThis<DictionaryOpt<unknown>>();
  * @returns A long integer value, the request ID, that uniquely identifies the entry in the callback list.
  */
 export const requestAnimationFrame: (callback: FrameRequestCallback) => number =
-  global_.requestAnimationFrame?.bind(global_) ??
-  ((callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 1000 / 60));
+  /* #__PURE__ */ globalThis.requestAnimationFrame?.bind(globalThis) ??
+  /* #__PURE__ */ ((callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 1000 / 60));
 
 /**
  * Ensures compatibility for `requestIdleCallback` by using the native API.
@@ -26,8 +26,8 @@ export const requestAnimationFrame: (callback: FrameRequestCallback) => number =
  * @returns An ID which can be used to cancel the callback by calling `cancelIdleCallback()`.
  */
 export const requestIdleCallback: (callback: (deadline: IdleDeadline) => void, options?: IdleRequestOptions) => number =
-  global_.requestIdleCallback?.bind(global_) ??
-  ((
+  /* #__PURE__ */ globalThis.requestIdleCallback?.bind(globalThis) ??
+  /* #__PURE__ */ ((
     callback: (deadline: IdleDeadline) => void,
     // options is not used in the fallback but kept for API consistency
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/random/src/main.ts
+++ b/packages/random/src/main.ts
@@ -1,12 +1,12 @@
 import {getGlobalThis} from '@alwatr/global-this';
 import {packageTracer} from '@alwatr/package-tracer';
 
-const globalThis = getGlobalThis();
+const globalThis = /* #__PURE__ */ getGlobalThis();
 
 __dev_mode__: packageTracer.add(__package_name__, __package_version__);
 
 // Use the native crypto module when available for better randomness
-const hasCrypto = typeof globalThis.crypto !== 'undefined';
+const hasCrypto = /* #__PURE__ */ (() => typeof globalThis.crypto !== 'undefined')();
 
 /**
  * Converts a Uint8Array or number array into a hexadecimal string representation.

--- a/packages/synapse/src/directiveClass.ts
+++ b/packages/synapse/src/directiveClass.ts
@@ -34,7 +34,7 @@ export abstract class DirectiveBase {
     this.element_ = element;
 
     (async () => {
-      await delay.immediate();
+      await delay.nextMicrotask();
       await this.init_();
       await this.update_();
     })();

--- a/packages/synapse/src/lib.ts
+++ b/packages/synapse/src/lib.ts
@@ -5,7 +5,7 @@ import type {DirectiveConstructor} from './directiveDecorator.js';
 /**
  * Alwatr Synapse Logger.
  */
-export const logger = createLogger('alwatr/synapse');
+export const logger = /* #__PURE__ */ createLogger('alwatr/synapse');
 
 /**
  * The registry for all directives.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,7 +2939,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
     "@typescript-eslint/parser": "npm:^7.18.0"
-    conventional-changelog-conventionalcommits: "npm:9.1.0"
+    conventional-changelog-conventionalcommits: "npm:^9.1.0"
     conventional-commits-filter: "npm:^5.0.0"
     eslint: "npm:^8.57.1"
     eslint-import-resolver-typescript: "npm:^4.4.4"
@@ -3594,7 +3594,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:9.1.0":
+"conventional-changelog-conventionalcommits@npm:^9.1.0":
   version: 9.1.0
   resolution: "conventional-changelog-conventionalcommits@npm:9.1.0"
   dependencies:


### PR DESCRIPTION
Redesign the `@alwatr/delay` module to enhance its API and correct implementations. Introduce a unified `delay` object for cleaner usage, simplify function names, and remove confusing fallbacks. Update documentation for clarity and structure. Ensure compatibility with modern JavaScript features and optimize performance. Breaking changes require users to adapt their code to the new API.