### PR TITLE
Add ESLint rule for explicit member accessibility

### DIFF
--- a/packages/eslint-config/eslint-config.cjs
+++ b/packages/eslint-config/eslint-config.cjs
@@ -81,6 +81,7 @@ module.exports = {
         },
       },
     ],
+    '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/prefer-string-starts-ends-with': 'off',
     '@typescript-eslint/no-dynamic-delete': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',


### PR DESCRIPTION
Introduce a new ESLint rule to enforce explicit member accessibility in TypeScript code.