### PR TITLE
Refactor debounce API for consistency

### DIFF
--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -195,7 +195,7 @@ function MyComponent() {
 
 ### Using with `thisContext`
 
-When your func is a method on a class, `this` can lose its context. Pass the class instance to `thisContext` to ensure it's bound correctly.
+When your `func` is a method on a class, `this` can lose its context. Pass the class instance to `thisContext` to ensure it's bound correctly.
 
 ```typescript
 class ApiService {

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -104,7 +104,7 @@ This is the configuration object passed to `createDebouncer` or the `Debouncer` 
 | :------------ | :---------------------- | :------------------------------------------------------------------- | :---------- |
 | `func`        | `F extends AnyFunction` | **(Required)** The function to be debounced.                         | -           |
 | `delay`       | `number`                | **(Required)** The debounce delay in milliseconds.                   | -           |
-| `thisContext` | `ThisParameterType<F>`  | The `this` context for the func. Essential when using class methods. | `undefined` |
+| `thisContext` | `ThisParameterType<F>`  | The `this` context for the `func`. Essential when using class methods. | `undefined` |
 | `leading`     | `boolean`               | If `true`, executes the function on the leading edge.                | `false`     |
 | `trailing`    | `boolean`               | If `true`, executes the function on the trailing edge.               | `true`      |
 

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -73,7 +73,7 @@ import {createDebouncer} from '@alwatr/debounce';
 // 1. Create a debouncer instance
 const debouncer = createDebouncer({
   // The function you want to debounce
-  callback: (query: string) => {
+  func: (query: string) => {
     console.log(`Searching for: ${query}`);
   },
   // The delay in milliseconds
@@ -100,13 +100,13 @@ A factory function that creates a new `Debouncer` instance. It's the recommended
 
 This is the configuration object passed to `createDebouncer` or the `Debouncer` constructor.
 
-| Property      | Type                    | Description                                                              | Default     |
-| :------------ | :---------------------- | :----------------------------------------------------------------------- | :---------- |
-| `callback`    | `F extends AnyFunction` | **(Required)** The function to be debounced.                             | -           |
-| `delay`       | `number`                | **(Required)** The debounce delay in milliseconds.                       | -           |
-| `thisContext` | `ThisParameterType<F>`  | The `this` context for the callback. Essential when using class methods. | `undefined` |
-| `leading`     | `boolean`               | If `true`, executes the function on the leading edge.                    | `false`     |
-| `trailing`    | `boolean`               | If `true`, executes the function on the trailing edge.                   | `true`      |
+| Property      | Type                    | Description                                                          | Default     |
+| :------------ | :---------------------- | :------------------------------------------------------------------- | :---------- |
+| `func`        | `F extends AnyFunction` | **(Required)** The function to be debounced.                         | -           |
+| `delay`       | `number`                | **(Required)** The debounce delay in milliseconds.                   | -           |
+| `thisContext` | `ThisParameterType<F>`  | The `this` context for the func. Essential when using class methods. | `undefined` |
+| `leading`     | `boolean`               | If `true`, executes the function on the leading edge.                | `false`     |
+| `trailing`    | `boolean`               | If `true`, executes the function on the trailing edge.               | `true`      |
 
 ### `Debouncer` Instance
 
@@ -120,7 +120,7 @@ An instance of the `Debouncer` class returned by `createDebouncer`.
 #### Methods
 
 - **`trigger(...args: Parameters<F>): void`**
-  Triggers the debounce timer. Each call resets the timer. The arguments passed here will be forwarded to the `callback` function.
+  Triggers the debounce timer. Each call resets the timer. The arguments passed here will be forwarded to the `func` function.
 
 - **`cancel(): void`**
   Cancels any pending execution and clears internal state. This is crucial for preventing memory leaks.
@@ -143,7 +143,7 @@ In modern Single-Page Applications (SPAs) or any component-based architecture, c
 ```typescript
 class MyComponent {
   private debouncer = createDebouncer({
-    callback: this.doSomething,
+    func: this.doSomething,
     thisContext: this, // Bind `this` correctly!
     delay: 500,
   });
@@ -175,7 +175,7 @@ function MyComponent() {
   const debouncedApiCall = useMemo(
     () =>
       createDebouncer({
-        callback: (query) => fetch(`/api/search?q=${query}`),
+        func: (query) => fetch(`/api/search?q=${query}`),
         delay: 300,
       }),
     [],
@@ -195,12 +195,12 @@ function MyComponent() {
 
 ### Using with `thisContext`
 
-When your callback is a method on a class, `this` can lose its context. Pass the class instance to `thisContext` to ensure it's bound correctly.
+When your func is a method on a class, `this` can lose its context. Pass the class instance to `thisContext` to ensure it's bound correctly.
 
 ```typescript
 class ApiService {
   private debouncer = createDebouncer({
-    callback: this.sendRequest,
+    func: this.sendRequest,
     thisContext: this, // Ensures `this` inside `sendRequest` is `ApiService`
     delay: 500,
   });
@@ -309,7 +309,7 @@ import {createDebouncer} from '@alwatr/debounce';
 // ۱. یک نمونه دیبانسر بسازید
 const debouncer = createDebouncer({
   // تابعی که می‌خواهید دیبانس کنید
-  callback: (query: string) => {
+  func: (query: string) => {
     console.log(`در حال جستجو برای: ${query}`);
   },
   // تأخیر بر حسب میلی‌ثانیه
@@ -338,9 +338,9 @@ debouncer.trigger('علی');
 
 | ویژگی         | نوع                     | توضیحات                                                               | پیش‌فرض     |
 | :------------ | :---------------------- | :-------------------------------------------------------------------- | :---------- |
-| `callback`    | `F extends AnyFunction` | **(الزامی)** تابعی که باید دیبانس شود.                                | -           |
+| `func`        | `F extends AnyFunction` | **(الزامی)** تابعی که باید دیبانس شود.                                | -           |
 | `delay`       | `number`                | **(الزامی)** تأخیر دیبانس بر حسب میلی‌ثانیه.                          | -           |
-| `thisContext` | `ThisParameterType<F>`  | کانتکست `this` برای callback. هنگام استفاده از متدهای کلاس ضروری است. | `undefined` |
+| `thisContext` | `ThisParameterType<F>`  | کانتکست `this` برای func. هنگام استفاده از متدهای کلاس ضروری است.     | `undefined` |
 | `leading`     | `boolean`               | اگر `true` باشد، تابع در لبه بالارونده (leading edge) اجرا می‌شود.    | `false`     |
 | `trailing`    | `boolean`               | اگر `true` باشد، تابع در لبه پایین‌رونده (trailing edge) اجرا می‌شود. | `true`      |
 
@@ -356,7 +356,7 @@ debouncer.trigger('علی');
 #### متدها
 
 - **`trigger(...args: Parameters<F>): void`**
-  تایمر دیبانس را فعال می‌کند. هر فراخوانی، تایمر را ریست می‌کند. آرگومان‌های پاس داده شده به این متد، به تابع `callback` ارسال می‌شوند.
+  تایمر دیبانس را فعال می‌کند. هر فراخوانی، تایمر را ریست می‌کند. آرگومان‌های پاس داده شده به این متد، به تابع `func` ارسال می‌شوند.
 
 - **`cancel(): void`**
   هرگونه اجرای در حال انتظار را لغو کرده و وضعیت داخلی را پاک می‌کند. این متد برای جلوگیری از نشت حافظه بسیار حیاتی است.
@@ -379,7 +379,7 @@ debouncer.trigger('علی');
 ```typescript
 class MyComponent {
   private debouncer = createDebouncer({
-    callback: this.doSomething,
+    func: this.doSomething,
     thisContext: this, // `this` را به درستی متصل کنید!
     delay: 500,
   });
@@ -411,7 +411,7 @@ function MyComponent() {
   const debouncedApiCall = useMemo(
     () =>
       createDebouncer({
-        callback: (query) => fetch(`/api/search?q=${query}`),
+        func: (query) => fetch(`/api/search?q=${query}`),
         delay: 300,
       }),
     [],
@@ -431,12 +431,12 @@ function MyComponent() {
 
 ### استفاده با `thisContext`
 
-زمانی که `callback` شما یک متد از یک کلاس است، `this` ممکن است کانتکست خود را از دست بدهد. برای اطمینان از اتصال صحیح، نمونه کلاس را به `thisContext` پاس دهید.
+زمانی که `func` شما یک متد از یک کلاس است، `this` ممکن است کانتکست خود را از دست بدهد. برای اطمینان از اتصال صحیح، نمونه کلاس را به `thisContext` پاس دهید.
 
 ```typescript
 class ApiService {
   private debouncer = createDebouncer({
-    callback: this.sendRequest,
+    func: this.sendRequest,
     thisContext: this, // تضمین می‌کند که `this` در داخل `sendRequest` همان `ApiService` است
     delay: 500,
   });

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -340,7 +340,7 @@ debouncer.trigger('علی');
 | :------------ | :---------------------- | :-------------------------------------------------------------------- | :---------- |
 | `func`        | `F extends AnyFunction` | **(الزامی)** تابعی که باید دیبانس شود.                                | -           |
 | `delay`       | `number`                | **(الزامی)** تأخیر دیبانس بر حسب میلی‌ثانیه.                          | -           |
-| `thisContext` | `ThisParameterType<F>`  | کانتکست `this` برای func. هنگام استفاده از متدهای کلاس ضروری است.     | `undefined` |
+| `thisContext` | `ThisParameterType<F>`  | کانتکست `this` برای `func`. هنگام استفاده از متدهای کلاس ضروری است.     | `undefined` |
 | `leading`     | `boolean`               | اگر `true` باشد، تابع در لبه بالارونده (leading edge) اجرا می‌شود.    | `false`     |
 | `trailing`    | `boolean`               | اگر `true` باشد، تابع در لبه پایین‌رونده (trailing edge) اجرا می‌شود. | `true`      |
 

--- a/packages/debounce/src/debounce.ts
+++ b/packages/debounce/src/debounce.ts
@@ -48,7 +48,7 @@ export class Debouncer<F extends AnyFunction> {
 
   /**
    * Triggers the debounced function with the stored `thisContext`.
-   * @param args The arguments to pass to the func.
+   * @param args The arguments to pass to the `func`.
    * 
    * @example
    * ```typescript

--- a/packages/debounce/src/debounce.ts
+++ b/packages/debounce/src/debounce.ts
@@ -10,7 +10,7 @@ import type {DebouncerConfig} from './type.ts';
  * @example
  * ```typescript
  * const debouncer = new Debouncer({
- *   callback: (text: string) => console.log('Searching:', text),
+ *   func: (text: string) => console.log('Searching:', text),
  *   delay: 300,
  *   leading: false,
  *   trailing: true,
@@ -22,7 +22,7 @@ import type {DebouncerConfig} from './type.ts';
  * 
  * // Advanced: With leading edge
  * const leadingDebouncer = new Debouncer({
- *   callback: () => console.log('Immediate and delayed'),
+ *   func: () => console.log('Immediate and delayed'),
  *   delay: 500,
  *   leading: true,
  *   trailing: true,
@@ -48,12 +48,12 @@ export class Debouncer<F extends AnyFunction> {
 
   /**
    * Triggers the debounced function with the stored `thisContext`.
-   * @param args The arguments to pass to the callback.
+   * @param args The arguments to pass to the func.
    * 
    * @example
    * ```typescript
    * const debouncer = new Debouncer({
-   *   callback: (value: number) => console.log('Value:', value),
+   *   func: (value: number) => console.log('Value:', value),
    *   delay: 500,
    * });
    * debouncer.trigger(42); // Logs after 500ms if not triggered again
@@ -90,7 +90,7 @@ export class Debouncer<F extends AnyFunction> {
    * @example
    * ```typescript
    * const debouncer = new Debouncer({
-   *   callback: () => console.log('Executed'),
+   *   func: () => console.log('Executed'),
    *   delay: 1000,
    * });
    * debouncer.trigger();
@@ -121,7 +121,7 @@ export class Debouncer<F extends AnyFunction> {
    * @example
    * ```typescript
    * const debouncer = new Debouncer({
-   *   callback: () => console.log('Flushed'),
+   *   func: () => console.log('Flushed'),
    *   delay: 1000,
    * });
    * debouncer.trigger();
@@ -145,7 +145,7 @@ export class Debouncer<F extends AnyFunction> {
   private invoke__(): void {
     if (this.lastArgs__) {
       // `thisContext` is now read directly from the stored config.
-      this.config__.callback.apply(this.config__.thisContext, this.lastArgs__);
+      this.config__.func.apply(this.config__.thisContext, this.lastArgs__);
     }
   }
 }
@@ -157,7 +157,7 @@ export class Debouncer<F extends AnyFunction> {
  * @example
  * ```typescript
  * const debouncer = createDebouncer({
- *   callback: (text: string) => console.log('Searching:', text),
+ *   func: (text: string) => console.log('Searching:', text),
  *   delay: 300,
  *   leading: false,
  *   trailing: true,
@@ -170,7 +170,7 @@ export class Debouncer<F extends AnyFunction> {
  * // With custom thisContext
  * const obj = { log: (msg: string) => console.log('Obj:', msg) };
  * const debouncerWithContext = createDebouncer({
- *   callback: obj.log,
+ *   func: obj.log,
  *   thisContext: obj,
  *   delay: 200,
  * });

--- a/packages/debounce/src/type.ts
+++ b/packages/debounce/src/type.ts
@@ -7,7 +7,7 @@ import type {} from '@alwatr/type-helper';
  * Key notes:
  * - `leading` and `trailing` control execution timing: leading executes immediately on first trigger, trailing after delay.
  * - If both are true, execution happens on first trigger and last trigger (after delay).
- * - `thisContext` ensures the callback is bound to the correct `this` value, useful in class methods or event handlers.
+ * - `thisContext` ensures the func is bound to the correct `this` value, useful in class methods or event handlers.
  * - `delay` must be a positive number.
  */
 export interface DebouncerConfig<F extends AnyFunction> {
@@ -15,12 +15,12 @@ export interface DebouncerConfig<F extends AnyFunction> {
    * The function to be executed after the delay.
    * Can be any function type, with type safety enforced by generics.
    */
-  callback: F;
+  func: F;
 
   /**
-   * The `this` context to be used when invoking the callback.
+   * The `this` context to be used when invoking the func.
    * If provided, it will be stored and used for all invocations.
-   * Omit if the callback doesn't rely on `this` or uses arrow functions.
+   * Omit if the func doesn't rely on `this` or uses arrow functions.
    */
   thisContext?: ThisParameterType<F>;
 

--- a/packages/debounce/src/type.ts
+++ b/packages/debounce/src/type.ts
@@ -7,7 +7,7 @@ import type {} from '@alwatr/type-helper';
  * Key notes:
  * - `leading` and `trailing` control execution timing: leading executes immediately on first trigger, trailing after delay.
  * - If both are true, execution happens on first trigger and last trigger (after delay).
- * - `thisContext` ensures the func is bound to the correct `this` value, useful in class methods or event handlers.
+ * - `thisContext` ensures the `func` is bound to the correct `this` value, useful in class methods or event handlers.
  * - `delay` must be a positive number.
  */
 export interface DebouncerConfig<F extends AnyFunction> {


### PR DESCRIPTION
Rename 'callback' to 'func' in the debounce API for improved consistency across the codebase. Update documentation and examples accordingly.