### PR TITLE
Update version references to schemaVersion

### DIFF
--- a/packages/local-storage/README.md
+++ b/packages/local-storage/README.md
@@ -14,9 +14,9 @@ It's designed to handle data structure migrations automatically, preventing issu
 
 This library is built upon a few simple but powerful concepts:
 
-1. **Provider Pattern**: Instead of using static functions, you create an _instance_ of a `LocalStorageProvider` for each unique data item you want to manage. This instance is configured once with a name, version, and default value, and then used to interact with that specific item.
+1. **Provider Pattern**: Instead of using static functions, you create an _instance_ of a `LocalStorageProvider` for each unique data item you want to manage. This instance is configured once with a name, schemaVersion, and default value, and then used to interact with that specific item.
 
-2. **Versioning & Automatic Migration**: When you initialize a provider with a new `version` number, it automatically removes all older versions of that data from `localStorage`. This prevents conflicts and ensures the application is working with the correct data structure.
+2. **Versioning & Automatic Migration**: When you initialize a provider with a new `schemaVersion` number, it automatically removes all older versions of that data from `localStorage`. This prevents conflicts and ensures the application is working with the correct data structure.
 
 3. **Facade Factory Function**: The `createLocalStorageProvider` function acts as a clean entry point (Facade) to the library. This simplifies the API and decouples your code from the internal class implementation, making future library upgrades safer and easier.
 
@@ -51,7 +51,7 @@ interface UserSettings {
 // Create a provider for user settings
 const userSettingsProvider = createLocalStorageProvider<UserSettings>({
   name: 'user-settings',
-  version: 1,
+  schemaVersion: 1,
   defaultValue: {
     theme: 'light',
     notifications: true,
@@ -95,7 +95,7 @@ This method is highly efficient as it **does not** require a `defaultValue` and 
 ```typescript
 import {LocalStorageProvider} from '@alwatr/local-storage';
 
-const formMeta = {name: 'user-survey-form', version: 1};
+const formMeta = {name: 'user-survey-form', schemaVersion: 1};
 
 if (LocalStorageProvider.has(formMeta)) {
   // The user has already filled out the form.
@@ -119,7 +119,7 @@ userSettingsProvider.remove();
 
 - **Always use the `createLocalStorageProvider` factory function.** It provides a stable API that protects your code from internal library changes.
 - **Prefer `LocalStorageProvider.has()` for existence checks.** It's the most performant and cleanest way to check for data without the overhead of creating an instance and providing a `defaultValue`.
-- **Increment the `version` number** whenever you make a breaking change to your data structure. The library will handle the cleanup of old data automatically.
+- **Increment the `schemaVersion` number** whenever you make a breaking change to your data structure. The library will handle the cleanup of old data automatically.
 
 ---
 
@@ -152,9 +152,9 @@ Contributions are welcome! Please read our [contribution guidelines](https://git
 
 این کتابخانه بر پایه چند مفهوم ساده اما قدرتمند بنا شده است:
 
-1. **الگوی Provider (ارائه‌دهنده)**: به جای استفاده از توابع استاتیک، شما برای هر آیتم داده‌ای که می‌خواهید مدیریت کنید، یک _نمونه (instance)_ از `LocalStorageProvider` می‌سازید. این نمونه یک بار با `name`, `version` و `defaultValue` پیکربندی شده و سپس برای تعامل با آن آیتم خاص استفاده می‌شود.
+1. **الگوی Provider (ارائه‌دهنده)**: به جای استفاده از توابع استاتیک، شما برای هر آیتم داده‌ای که می‌خواهید مدیریت کنید، یک _نمونه (instance)_ از `LocalStorageProvider` می‌سازید. این نمونه یک بار با `name`, `schemaVersion` و `defaultValue` پیکربندی شده و سپس برای تعامل با آن آیتم خاص استفاده می‌شود.
 
-2. **نسخه‌بندی و مهاجرت خودکار**: هنگامی که شما یک Provider را با شماره `version` جدیدی مقداردهی اولیه می‌کنید، این کتابخانه به طور خودکار تمام نسخه‌های قدیمی‌تر آن داده را از `localStorage` حذف می‌کند. این کار از تداخل جلوگیری کرده و تضمین می‌کند که اپلیکیشن همیشه با ساختار داده صحیح کار می‌کند.
+2. **نسخه‌بندی و مهاجرت خودکار**: هنگامی که شما یک Provider را با شماره `schemaVersion` جدیدی مقداردهی اولیه می‌کنید، این کتابخانه به طور خودکار تمام نسخه‌های قدیمی‌تر آن داده را از `localStorage` حذف می‌کند. این کار از تداخل جلوگیری کرده و تضمین می‌کند که اپلیکیشن همیشه با ساختار داده صحیح کار می‌کند.
 
 3. **تابع سازنده Facade**: تابع `createLocalStorageProvider` به عنوان یک نقطه ورود تمیز (Facade) به کتابخانه عمل می‌کند. این کار API را ساده کرده و کد شما را از پیاده‌سازی داخلی کلاس‌ها جدا (decouple) می‌سازد، که باعث می‌شود ارتقاء کتابخانه در آینده امن‌تر و آسان‌تر باشد.
 
@@ -189,7 +189,7 @@ interface UserSettings {
 // یک provider برای تنظیمات کاربر بسازید
 const userSettingsProvider = createLocalStorageProvider<UserSettings>({
   name: 'user-settings',
-  version: 1,
+  schemaVersion: 1,
   defaultValue: {
     theme: 'light',
     notifications: true,
@@ -233,7 +233,7 @@ console.log(currentSettings.theme); // "dark"
 ```typescript
 import {LocalStorageProvider} from '@alwatr/local-storage';
 
-const formMeta = {name: 'user-survey-form', version: 1};
+const formMeta = {name: 'user-survey-form', schemaVersion: 1};
 
 if (LocalStorageProvider.has(formMeta)) {
   // داده وجود دارد. کاربر قبلاً فرم را پر کرده است.
@@ -257,7 +257,7 @@ userSettingsProvider.remove();
 
 - **همیشه از تابع سازنده `createLocalStorageProvider` استفاده کنید.** این تابع یک API پایدار فراهم می‌کند که کد شما را در برابر تغییرات داخلی کتابخانه محافظت می‌کند.
 - **برای بررسی وجود داده، `LocalStorageProvider.has()` را ترجیح دهید.** این کارآمدترین و تمیزترین روش برای بررسی وجود داده بدون سربار ساختن یک نمونه و تعریف `defaultValue` است.
-- **هر زمان که یک تغییر ساختاری در داده‌های خود ایجاد کردید که با نسخه‌های قبلی ناسازگار است، شماره `version` را افزایش دهید.** کتابخانه پاک‌سازی داده‌های قدیمی را به صورت خودکار انجام خواهد داد.
+- **هر زمان که یک تغییر ساختاری در داده‌های خود ایجاد کردید که با نسخه‌های قبلی ناسازگار است، شماره `schemaVersion` را افزایش دهید.** کتابخانه پاک‌سازی داده‌های قدیمی را به صورت خودکار انجام خواهد داد.
 
 ## حامیان (Sponsors)
 

--- a/packages/local-storage/src/local-storage.provider.ts
+++ b/packages/local-storage/src/local-storage.provider.ts
@@ -26,7 +26,7 @@ export class LocalStorageProvider<T extends JsonValue> {
   public static readonly version = __package_version__;
 
   private readonly key__: string;
-  protected readonly logger_ = createLogger(`local-storage-provider: ${this.config_.name}, v: ${this.config_.version}`);
+  protected readonly logger_ = createLogger(`local-storage-provider: ${this.config_.name}, v: ${this.config_.schemaVersion}`);
 
   constructor(protected readonly config_: LocalStorageProviderConfig<T>) {
     this.logger_.logMethodArgs?.('constructor', {config: this.config_});
@@ -36,11 +36,11 @@ export class LocalStorageProvider<T extends JsonValue> {
 
   /**
    * Generates the versioned storage key.
-   * @param meta - An object containing the name and version.
+   * @param meta - An object containing the name and schemaVersion.
    * @returns The versioned key string.
    */
   public static getKey(meta: StorageMeta): string {
-    return `${meta.name}.v${meta.version}`;
+    return `${meta.name}.v${meta.schemaVersion}`;
   }
 
   /**
@@ -52,7 +52,7 @@ export class LocalStorageProvider<T extends JsonValue> {
    *
    * @example
    * ```typescript
-   * const formExists = LocalStorageProvider.has({ name: 'user-form', version: 1 });
+   * const formExists = LocalStorageProvider.has({ name: 'user-form', schemaVersion: 1 });
    * if (formExists) {
    *   // Show the "Thank you" message
    * } else {
@@ -122,11 +122,11 @@ export class LocalStorageProvider<T extends JsonValue> {
    * Manages data migration by removing all previous versions of the item.
    */
   private migrate__(): void {
-    if (this.config_.version <= 1) return;
+    if (this.config_.schemaVersion <= 1) return;
 
     // Iterate from v1 up to the version just before the current one and remove them.
-    for (let i = 1; i < this.config_.version; i++) {
-      const oldKey = LocalStorageProvider.getKey({name: this.config_.name, version: i});
+    for (let i = 1; i < this.config_.schemaVersion; i++) {
+      const oldKey = LocalStorageProvider.getKey({name: this.config_.name, schemaVersion: i});
       localStorage.removeItem(oldKey);
     }
   }

--- a/packages/local-storage/src/main.test.js
+++ b/packages/local-storage/src/main.test.js
@@ -28,14 +28,14 @@ describe('LocalStorageProvider', () => {
 
   describe('static getKey', () => {
     it('should generate the correct versioned key', () => {
-      const key = LocalStorageProvider.getKey({name: 'test', version: 1});
+      const key = LocalStorageProvider.getKey({name: 'test', schemaVersion: 1});
       expect(key).toBe('test.v1');
     });
 
     it('should handle different names and versions', () => {
-      const key1 = LocalStorageProvider.getKey({name: 'user-settings', version: 2});
+      const key1 = LocalStorageProvider.getKey({name: 'user-settings', schemaVersion: 2});
       expect(key1).toBe('user-settings.v2');
-      const key2 = LocalStorageProvider.getKey({name: 'form-data', version: 5});
+      const key2 = LocalStorageProvider.getKey({name: 'form-data', schemaVersion: 5});
       expect(key2).toBe('form-data.v5');
     });
   });
@@ -43,20 +43,20 @@ describe('LocalStorageProvider', () => {
   describe('static has', () => {
     it('should return true if item exists', () => {
       mockLocalStorage.getItem.mockReturnValue('{"value": "test"}');
-      const exists = LocalStorageProvider.has({name: 'test', version: 1});
+      const exists = LocalStorageProvider.has({name: 'test', schemaVersion: 1});
       expect(exists).toBe(true);
       expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test.v1');
     });
 
     it('should return false if item does not exist', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
-      const exists = LocalStorageProvider.has({name: 'test', version: 1});
+      const exists = LocalStorageProvider.has({name: 'test', schemaVersion: 1});
       expect(exists).toBe(false);
     });
 
     it('should return false for null value', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
-      const exists = LocalStorageProvider.has({name: 'test', version: 1});
+      const exists = LocalStorageProvider.has({name: 'test', schemaVersion: 1});
       expect(exists).toBe(false);
     });
   });
@@ -65,26 +65,26 @@ describe('LocalStorageProvider', () => {
     it('should initialize with config and migrate old versions', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 3,
+        schemaVersion: 3,
         defaultValue: {key: 'value'},
       });
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v1');
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v2');
     });
 
-    it('should not migrate if version is 1', () => {
+    it('should not migrate if schemaVersion is 1', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'value'},
       });
       expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
     });
 
-    it('should migrate multiple old versions for higher version', () => {
+    it('should migrate multiple old versions for higher schemaVersion', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 5,
+        schemaVersion: 5,
         defaultValue: {key: 'value'},
       });
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v1');
@@ -99,7 +99,7 @@ describe('LocalStorageProvider', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       const result = provider.read();
@@ -111,7 +111,7 @@ describe('LocalStorageProvider', () => {
       mockLocalStorage.getItem.mockReturnValue('{"key":"stored"}');
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       const result = provider.read();
@@ -122,7 +122,7 @@ describe('LocalStorageProvider', () => {
       mockLocalStorage.getItem.mockReturnValue('invalid json');
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       const result = provider.read();
@@ -133,7 +133,7 @@ describe('LocalStorageProvider', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {theme: 'dark', lastLogin: Date.now(), settings: [1, 2, 3]},
       });
       const result = provider.read();
@@ -146,7 +146,7 @@ describe('LocalStorageProvider', () => {
     it('should serialize and store the value', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       provider.write({key: 'newValue'});
@@ -159,7 +159,7 @@ describe('LocalStorageProvider', () => {
       });
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       expect(() => provider.write({key: 'value'})).not.toThrow();
@@ -168,7 +168,7 @@ describe('LocalStorageProvider', () => {
     it('should write different data types', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         /**
          * @type {string|number|Array<number>}
          */
@@ -187,7 +187,7 @@ describe('LocalStorageProvider', () => {
     it('should remove the item from storage', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       provider.remove();
@@ -197,7 +197,7 @@ describe('LocalStorageProvider', () => {
     it('should not throw if item does not exist', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default'},
       });
       expect(() => provider.remove()).not.toThrow();
@@ -208,7 +208,7 @@ describe('LocalStorageProvider', () => {
     it('should create a provider instance', () => {
       const provider = createLocalStorageProvider({
         name: 'factory-test',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {created: true},
       });
       expect(provider).toBeInstanceOf(LocalStorageProvider);
@@ -219,12 +219,12 @@ describe('LocalStorageProvider', () => {
     it('should handle different configurations', () => {
       const provider1 = createLocalStorageProvider({
         name: 'config1',
-        version: 2,
+        schemaVersion: 2,
         defaultValue: 'default1',
       });
       const provider2 = createLocalStorageProvider({
         name: 'config2',
-        version: 1,
+        schemaVersion: 1,
         defaultValue: {key: 'default2'},
       });
       expect(provider1.read()).toBe('default1');

--- a/packages/local-storage/src/type.ts
+++ b/packages/local-storage/src/type.ts
@@ -11,7 +11,7 @@ export interface StorageMeta {
    * The data structure version.
    * starting from 1 and incrementing by 1 for each new version.
    */
-  version: number;
+  schemaVersion: number;
 }
 
 export interface LocalStorageProviderConfig<T> extends StorageMeta {


### PR DESCRIPTION
Replace all instances of `version` with `schemaVersion` in the README and code to align with the updated data structure management.