### PR TITLE
Refactor LocalStorageProvider to remove defaultValue and simplify configuration

### DIFF
--- a/packages/local-storage/README.md
+++ b/packages/local-storage/README.md
@@ -14,13 +14,13 @@ It's designed to handle data structure migrations automatically, preventing issu
 
 This library is built upon a few simple but powerful concepts:
 
-1. **Provider Pattern**: Instead of using static functions, you create an _instance_ of a `LocalStorageProvider` for each unique data item you want to manage. This instance is configured once with a name, schemaVersion, and default value, and then used to interact with that specific item.
+1. **Provider Pattern**: Instead of using static functions, you create an _instance_ of a `LocalStorageProvider` for each unique data item you want to manage. This instance is configured once with a name and schemaVersion, and then used to interact with that specific item.
 
 2. **Versioning & Automatic Migration**: When you initialize a provider with a new `schemaVersion` number, it automatically removes all older versions of that data from `localStorage`. This prevents conflicts and ensures the application is working with the correct data structure.
 
 3. **Facade Factory Function**: The `createLocalStorageProvider` function acts as a clean entry point (Facade) to the library. This simplifies the API and decouples your code from the internal class implementation, making future library upgrades safer and easier.
 
-4. **Static Existence Check**: The static method `LocalStorageProvider.has()` allows you to check if data exists _before_ creating a provider instance. This is highly efficient for scenarios where you only need to know if the data is present, without needing the data itself or a default value.
+4. **Static Existence Check**: The static method `LocalStorageProvider.has()` allows you to check if data exists _before_ creating a provider instance. This is highly efficient for scenarios where you only need to know if the data is present, without needing the data itself.
 
 ## Installation
 
@@ -52,11 +52,6 @@ interface UserSettings {
 const userSettingsProvider = createLocalStorageProvider<UserSettings>({
   name: 'user-settings',
   schemaVersion: 1,
-  defaultValue: {
-    theme: 'light',
-    notifications: true,
-    lastLogin: null,
-  },
 });
 ```
 
@@ -77,20 +72,24 @@ userSettingsProvider.write({
 Use the `.read()` method to retrieve the data.
 
 - If a value exists in `localStorage` and is valid JSON, it will be parsed and returned.
-- If no value exists or if the stored value is corrupted (invalid JSON), the `defaultValue` will be written to `localStorage` and then returned. This guarantees you always receive a value of the correct type.
+- If no value exists or if the stored value is corrupted (invalid JSON), it returns `null`.
 
 <!-- end list -->
 
 ```typescript
 const currentSettings = userSettingsProvider.read();
-console.log(currentSettings.theme); // "dark"
+if (currentSettings) {
+  console.log(currentSettings.theme); // "dark"
+} else {
+  // Handle the case where no data exists
+}
 ```
 
 ### 4\. Checking for Data Existence (The Recommended Way)
 
 This is a critical feature for many applications. Before rendering a component or creating a full provider instance, you might need to check if the user has already saved data. Use the static `LocalStorageProvider.has()` method for this.
 
-This method is highly efficient as it **does not** require a `defaultValue` and does not create a class instance.
+This method is highly efficient as it **does not** require creating a class instance.
 
 ```typescript
 import {LocalStorageProvider} from '@alwatr/local-storage';
@@ -118,7 +117,7 @@ userSettingsProvider.remove();
 ## Best Practices
 
 - **Always use the `createLocalStorageProvider` factory function.** It provides a stable API that protects your code from internal library changes.
-- **Prefer `LocalStorageProvider.has()` for existence checks.** It's the most performant and cleanest way to check for data without the overhead of creating an instance and providing a `defaultValue`.
+- **Prefer `LocalStorageProvider.has()` for existence checks.** It's the most performant and cleanest way to check for data without the overhead of creating an instance.
 - **Increment the `schemaVersion` number** whenever you make a breaking change to your data structure. The library will handle the cleanup of old data automatically.
 
 ---
@@ -152,13 +151,13 @@ Contributions are welcome! Please read our [contribution guidelines](https://git
 
 این کتابخانه بر پایه چند مفهوم ساده اما قدرتمند بنا شده است:
 
-1. **الگوی Provider (ارائه‌دهنده)**: به جای استفاده از توابع استاتیک، شما برای هر آیتم داده‌ای که می‌خواهید مدیریت کنید، یک _نمونه (instance)_ از `LocalStorageProvider` می‌سازید. این نمونه یک بار با `name`, `schemaVersion` و `defaultValue` پیکربندی شده و سپس برای تعامل با آن آیتم خاص استفاده می‌شود.
+1. **الگوی Provider (ارائه‌دهنده)**: به جای استفاده از توابع استاتیک، شما برای هر آیتم داده‌ای که می‌خواهید مدیریت کنید، یک _نمونه (instance)_ از `LocalStorageProvider` می‌سازید. این نمونه یک بار با `name` و `schemaVersion` پیکربندی شده و سپس برای تعامل با آن آیتم خاص استفاده می‌شود.
 
 2. **نسخه‌بندی و مهاجرت خودکار**: هنگامی که شما یک Provider را با شماره `schemaVersion` جدیدی مقداردهی اولیه می‌کنید، این کتابخانه به طور خودکار تمام نسخه‌های قدیمی‌تر آن داده را از `localStorage` حذف می‌کند. این کار از تداخل جلوگیری کرده و تضمین می‌کند که اپلیکیشن همیشه با ساختار داده صحیح کار می‌کند.
 
 3. **تابع سازنده Facade**: تابع `createLocalStorageProvider` به عنوان یک نقطه ورود تمیز (Facade) به کتابخانه عمل می‌کند. این کار API را ساده کرده و کد شما را از پیاده‌سازی داخلی کلاس‌ها جدا (decouple) می‌سازد، که باعث می‌شود ارتقاء کتابخانه در آینده امن‌تر و آسان‌تر باشد.
 
-4. **بررسی استاتیک وجود داده**: متد استاتیک `LocalStorageProvider.has()` به شما اجازه می‌دهد وجود داده را _قبل_ از ساختن یک نمونه از Provider بررسی کنید. این روش برای سناریوهایی که فقط نیاز دارید بدانید داده‌ای وجود دارد یا نه (بدون نیاز به خود داده یا مقدار پیش‌فرض) بسیار کارآمد است.
+4. **بررسی استاتیک وجود داده**: متد استاتیک `LocalStorageProvider.has()` به شما اجازه می‌دهد وجود داده را _قبل_ از ساختن یک نمونه از Provider بررسی کنید. این روش برای سناریوهایی که فقط نیاز دارید بدانید داده‌ای وجود دارد یا نه بسیار کارآمد است.
 
 ## نصب
 
@@ -190,11 +189,6 @@ interface UserSettings {
 const userSettingsProvider = createLocalStorageProvider<UserSettings>({
   name: 'user-settings',
   schemaVersion: 1,
-  defaultValue: {
-    theme: 'light',
-    notifications: true,
-    lastLogin: null,
-  },
 });
 ```
 
@@ -215,20 +209,24 @@ userSettingsProvider.write({
 از متد `.read()` برای بازیابی داده استفاده کنید.
 
 - اگر مقداری در `localStorage` وجود داشته باشد و JSON معتبر باشد، آن مقدار parse شده و برگردانده می‌شود.
-- اگر مقداری وجود نداشته باشد یا مقدار ذخیره شده خراب باشد (JSON نامعتبر)، `defaultValue` در `localStorage` نوشته شده و سپس برگردانده می‌شود. این تضمین می‌کند که شما همیشه یک مقدار با نوع صحیح دریافت می‌کنید.
+- اگر مقداری وجود نداشته باشد یا مقدار ذخیره شده خراب باشد (JSON نامعتبر)، `null` برگردانده می‌شود.
 
 <!-- end list -->
 
 ```typescript
 const currentSettings = userSettingsProvider.read();
-console.log(currentSettings.theme); // "dark"
+if (currentSettings) {
+  console.log(currentSettings.theme); // "dark"
+} else {
+  // مدیریت حالت عدم وجود داده
+}
 ```
 
 ### ۴. بررسی وجود داده (روش پیشنهادی)
 
 این یک قابلیت حیاتی برای بسیاری از اپلیکیشن‌ها است. قبل از رندر کردن یک کامپوننت یا ساختن یک نمونه کامل از Provider، ممکن است لازم باشد بررسی کنید که آیا کاربر قبلاً داده‌ای ذخیره کرده است یا خیر. برای این کار از متد استاتیک `LocalStorageProvider.has()` استفاده کنید.
 
-این متد بسیار کارآمد است زیرا **نیازی** به `defaultValue` ندارد و یک نمونه از کلاس نمی‌سازد.
+این متد بسیار کارآمد است زیرا یک نمونه از کلاس نمی‌سازد.
 
 ```typescript
 import {LocalStorageProvider} from '@alwatr/local-storage';
@@ -256,7 +254,7 @@ userSettingsProvider.remove();
 ## بهترین روش‌ها (Best Practices)
 
 - **همیشه از تابع سازنده `createLocalStorageProvider` استفاده کنید.** این تابع یک API پایدار فراهم می‌کند که کد شما را در برابر تغییرات داخلی کتابخانه محافظت می‌کند.
-- **برای بررسی وجود داده، `LocalStorageProvider.has()` را ترجیح دهید.** این کارآمدترین و تمیزترین روش برای بررسی وجود داده بدون سربار ساختن یک نمونه و تعریف `defaultValue` است.
+- **برای بررسی وجود داده، `LocalStorageProvider.has()` را ترجیح دهید.** این کارآمدترین و تمیزترین روش برای بررسی وجود داده بدون سربار ساختن یک نمونه است.
 - **هر زمان که یک تغییر ساختاری در داده‌های خود ایجاد کردید که با نسخه‌های قبلی ناسازگار است، شماره `schemaVersion` را افزایش دهید.** کتابخانه پاک‌سازی داده‌های قدیمی را به صورت خودکار انجام خواهد داد.
 
 ## حامیان (Sponsors)

--- a/packages/local-storage/src/facade.ts
+++ b/packages/local-storage/src/facade.ts
@@ -24,6 +24,6 @@ import type {LocalStorageProviderConfig} from './type.js';
  * console.log(currentSettings); // { theme: 'dark', notifications: false }
  * ```
  */
-export function createLocalStorageProvider<T extends JsonValue>(config: LocalStorageProviderConfig<T>): LocalStorageProvider<T> {
+export function createLocalStorageProvider<T extends JsonValue>(config: LocalStorageProviderConfig): LocalStorageProvider<T> {
   return new LocalStorageProvider<T>(config);
 }

--- a/packages/local-storage/src/facade.ts
+++ b/packages/local-storage/src/facade.ts
@@ -12,8 +12,7 @@ import type {LocalStorageProviderConfig} from './type.js';
  * ```typescript
  * const userSettings = createLocalStorageProvider({
  *   name: 'user-settings',
- *   schemaVersion: 1,
- *   defaultValue: { theme: 'light', notifications: true }
+ *   schemaVersion: 1
  * });
  *
  * // Write new settings

--- a/packages/local-storage/src/local-storage.provider.ts
+++ b/packages/local-storage/src/local-storage.provider.ts
@@ -69,6 +69,10 @@ export class LocalStorageProvider<T extends JsonValue> {
    * const exists = LocalStorageProvider.has({ name: 'user-form', schemaVersion: 1 });
    * ```
    */
+  public static has(config: LocalStorageProviderConfig): boolean {
+    const key = LocalStorageProvider.getKey(config);
+    return localStorage.getItem(key) !== null;
+  }
 
   /**
    * Checks if the current versioned item exists in localStorage.

--- a/packages/local-storage/src/local-storage.provider.ts
+++ b/packages/local-storage/src/local-storage.provider.ts
@@ -57,19 +57,29 @@ export class LocalStorageProvider<T extends JsonValue> {
   }
 
   /**
-   * Statically checks if a versioned item exists in localStorage.
-   * This method provides a high-performance way to check for data existence without the overhead of creating a full provider instance.
+   * Checks if a versioned item exists in localStorage for the given configuration.
+   * This static method allows checking for the existence of a specific versioned item
+   * without instantiating the provider.
    *
-   * @param meta - An object containing the name and version of the item to check.
-   * @returns `true` if the item exists, otherwise `false`.
+   * @param config - The configuration object containing the name and schemaVersion.
+   * @returns `true` if the item exists in localStorage, otherwise `false`.
    *
    * @example
    * ```typescript
-   * const formExists = LocalStorageProvider.has({ name: 'user-form', schemaVersion: 1 });
-   * if (formExists) {
-   *   // Show the "Thank you" message
-   * } else {
-   *   // Show the form
+   * const exists = LocalStorageProvider.has({ name: 'user-form', schemaVersion: 1 });
+   * ```
+   */
+
+  /**
+   * Checks if the current versioned item exists in localStorage.
+   *
+   * @returns `true` if the item exists in localStorage, otherwise `false`.
+   *
+   * @example
+   * ```typescript
+   * const provider = new LocalStorageProvider({ name: 'profile', schemaVersion: 2 });
+   * if (provider.has()) {
+   *   // Item exists
    * }
    * ```
    */

--- a/packages/local-storage/src/local-storage.provider.ts
+++ b/packages/local-storage/src/local-storage.provider.ts
@@ -1,6 +1,6 @@
 import {createLogger} from '@alwatr/logger';
 
-import type {LocalStorageProviderConfig, StorageMeta} from './type.js';
+import type {LocalStorageProviderConfig} from './type.js';
 
 /**
  * A provider class for managing a specific, versioned item in localStorage.
@@ -28,20 +28,11 @@ export class LocalStorageProvider<T extends JsonValue> {
   private readonly key__: string;
   protected readonly logger_;
 
-  private readonly meta__: Readonly<StorageMeta>;
-
-  protected readonly defaultValue__: T;
-
-  constructor(config: LocalStorageProviderConfig<T>) {
+  constructor(config: LocalStorageProviderConfig) {
     this.logger_ = createLogger(`local-storage-provider: ${config.name}, v: ${config.schemaVersion}`);
     this.logger_.logMethodArgs?.('constructor', {config});
-    this.meta__ = {
-      name: config.name,
-      schemaVersion: config.schemaVersion,
-    };
-    this.key__ = LocalStorageProvider.getKey(this.meta__);
-    this.defaultValue__ = this.convertDataType__(config.defaultValue);
-    this.migrate__();
+    this.key__ = LocalStorageProvider.getKey(config);
+    LocalStorageProvider.clearPreviousStorageVersions(config);
   }
 
   /**
@@ -49,8 +40,21 @@ export class LocalStorageProvider<T extends JsonValue> {
    * @param meta - An object containing the name and schemaVersion.
    * @returns The versioned key string.
    */
-  public static getKey(meta: StorageMeta): string {
-    return `${meta.name}.v${meta.schemaVersion}`;
+  public static getKey(config: LocalStorageProviderConfig): string {
+    return `${config.name}.v${config.schemaVersion}`;
+  }
+
+  /**
+   * Manages data migration by removing all previous versions of the item.
+   */
+  public static clearPreviousStorageVersions(config: LocalStorageProviderConfig): void {
+    if (config.schemaVersion < 1) return;
+
+    // Iterate from v1 up to the version just before the current one and remove them.
+    for (let i = 0; i < config.schemaVersion; i++) {
+      const oldKey = LocalStorageProvider.getKey({name: config.name, schemaVersion: i});
+      localStorage.removeItem(oldKey);
+    }
   }
 
   /**
@@ -70,45 +74,8 @@ export class LocalStorageProvider<T extends JsonValue> {
    * }
    * ```
    */
-  public static has(meta: StorageMeta): boolean {
-    const key = LocalStorageProvider.getKey(meta);
-    return localStorage.getItem(key) !== null;
-  }
-
-  /**
-   * Writes the default value to localStorage and returns it.
-   */
-  private handleDefault__(): T {
-    this.logger_.logMethodArgs?.('handleDefault__', this.defaultValue__);
-    try {
-      this.write(this.defaultValue__);
-    }
-    catch (err) {
-      this.logger_.error('write', 'write_default_error', {err});
-    }
-    return this.defaultValue__;
-  }
-
-  /**
-   * Converts the provided data to a JSON-compatible format by simulating
-   * a serialization/deserialization cycle. This ensures that the data
-   * conforms to the `T` type.
-   *
-   * @template T - The type of the input data.
-   * @param data - The data to be converted to a JSON-compatible format.
-   * @returns The converted data as `T`.
-   * @throws {Error} If the serialization/deserialization process fails.
-   */
-  private convertDataType__(data: T): T {
-    this.logger_.logMethod?.('convertDataType');
-    // Simulate real serialization/deserialization cycle for real types
-    try {
-      return JSON.parse(JSON.stringify(data)) as T;
-    }
-    catch (err) {
-      this.logger_.error('convertDataType__', 'convert_data_type_error', {err});
-      throw new Error('convert_data_type_error');
-    }
+  public has(): boolean {
+    return localStorage.getItem(this.key__) !== null;
   }
 
   /**
@@ -116,8 +83,9 @@ export class LocalStorageProvider<T extends JsonValue> {
    * If the item doesn't exist, is invalid JSON, or doesn't match the expected type,
    * it writes and returns the default value.
    */
-  public read(): T {
+  public read(): T | null {
     let value: string | null = null;
+
     try {
       value = localStorage.getItem(this.key__);
     }
@@ -125,9 +93,9 @@ export class LocalStorageProvider<T extends JsonValue> {
       this.logger_.error('read', 'read_local_storage_error', {err});
     }
 
-    if (value === null) {
+    if (!value) {
       this.logger_.logMethod?.('read//no_value');
-      return this.handleDefault__();
+      return null;
     }
 
     try {
@@ -137,7 +105,7 @@ export class LocalStorageProvider<T extends JsonValue> {
     }
     catch (err) {
       this.logger_.error('read', 'read_parse_error', {err});
-      return this.handleDefault__();
+      return null;
     }
   }
 
@@ -168,18 +136,5 @@ export class LocalStorageProvider<T extends JsonValue> {
    */
   public remove(): void {
     localStorage.removeItem(this.key__);
-  }
-
-  /**
-   * Manages data migration by removing all previous versions of the item.
-   */
-  private migrate__(): void {
-    if (this.meta__.schemaVersion <= 1) return;
-
-    // Iterate from v1 up to the version just before the current one and remove them.
-    for (let i = 1; i < this.meta__.schemaVersion; i++) {
-      const oldKey = LocalStorageProvider.getKey({name: this.meta__.name, schemaVersion: i});
-      localStorage.removeItem(oldKey);
-    }
   }
 }

--- a/packages/local-storage/src/local-storage.provider.ts
+++ b/packages/local-storage/src/local-storage.provider.ts
@@ -10,8 +10,7 @@ import type {LocalStorageProviderConfig} from './type.js';
  * ```typescript
  * const userSettings = new LocalStorageProvider({
  *   name: 'user-settings',
- *   version: 1,
- *   defaultValue: { theme: 'light', notifications: true }
+ *   version: 1
  * });
  *
  * // Write new settings
@@ -80,8 +79,7 @@ export class LocalStorageProvider<T extends JsonValue> {
 
   /**
    * Reads and parses the value from localStorage.
-   * If the item doesn't exist, is invalid JSON, or doesn't match the expected type,
-   * it writes and returns the default value.
+   * If the item doesn't exist or is invalid JSON, returns null.
    */
   public read(): T | null {
     let value: string | null = null;

--- a/packages/local-storage/src/main.test.js
+++ b/packages/local-storage/src/main.test.js
@@ -43,20 +43,32 @@ describe('LocalStorageProvider', () => {
   describe('static has', () => {
     it('should return true if item exists', () => {
       mockLocalStorage.getItem.mockReturnValue('{"value": "test"}');
-      const exists = LocalStorageProvider.has({name: 'test', schemaVersion: 1});
+      const provider = createLocalStorageProvider({
+        name: 'test',
+        schemaVersion: 1,
+      });
+      const exists = provider.has();
       expect(exists).toBe(true);
       expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test.v1');
     });
 
     it('should return false if item does not exist', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
-      const exists = LocalStorageProvider.has({name: 'test', schemaVersion: 1});
+      const provider = createLocalStorageProvider({
+        name: 'test',
+        schemaVersion: 1,
+      });
+      const exists = provider.has();
       expect(exists).toBe(false);
     });
 
     it('should return false for null value', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
-      const exists = LocalStorageProvider.has({name: 'test', schemaVersion: 1});
+      const provider = createLocalStorageProvider({
+        name: 'test',
+        schemaVersion: 1,
+      });
+      const exists = provider.has();
       expect(exists).toBe(false);
     });
   });
@@ -66,17 +78,15 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 3,
-        defaultValue: {key: 'value'},
       });
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v1');
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v2');
     });
 
-    it('should not migrate if schemaVersion is 1', () => {
+    it('should not migrate if schemaVersion is 0', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
-        schemaVersion: 1,
-        defaultValue: {key: 'value'},
+        schemaVersion: 0,
       });
       expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
     });
@@ -85,7 +95,6 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 5,
-        defaultValue: {key: 'value'},
       });
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v1');
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v2');
@@ -95,16 +104,14 @@ describe('LocalStorageProvider', () => {
   });
 
   describe('read', () => {
-    it('should return default value if no item exists', () => {
+    it('should return null if no item exists', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       const result = provider.read();
-      expect(result).toEqual({key: 'default'});
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith('test.v1', '{"key":"default"}');
+      expect(result).toBe(null);
     });
 
     it('should return parsed value if item exists', () => {
@@ -112,33 +119,19 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       const result = provider.read();
       expect(result).toEqual({key: 'stored'});
     });
 
-    it('should return default value on invalid JSON', () => {
+    it('should return null on invalid JSON', () => {
       mockLocalStorage.getItem.mockReturnValue('invalid json');
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       const result = provider.read();
-      expect(result).toEqual({key: 'default'});
-    });
-
-    it('should handle complex default values', () => {
-      mockLocalStorage.getItem.mockReturnValue(null);
-      const provider = createLocalStorageProvider({
-        name: 'test',
-        schemaVersion: 1,
-        defaultValue: {theme: 'dark', lastLogin: Date.now(), settings: [1, 2, 3]},
-      });
-      const result = provider.read();
-      expect(result.theme).toBe('dark');
-      expect(Array.isArray(result.settings)).toBe(true);
+      expect(result).toBe(null);
     });
   });
 
@@ -147,7 +140,6 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       provider.write({key: 'newValue'});
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('test.v1', '{"key":"newValue"}');
@@ -160,7 +152,6 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       expect(() => provider.write({key: 'value'})).not.toThrow();
     });
@@ -169,10 +160,6 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        /**
-         * @type {string|number|Array<number>}
-         */
-        defaultValue: '',
       });
       provider.write('string value');
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('test.v1', '"string value"');
@@ -188,7 +175,6 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       provider.remove();
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test.v1');
@@ -198,7 +184,6 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'test',
         schemaVersion: 1,
-        defaultValue: {key: 'default'},
       });
       expect(() => provider.remove()).not.toThrow();
     });
@@ -209,26 +194,21 @@ describe('LocalStorageProvider', () => {
       const provider = createLocalStorageProvider({
         name: 'factory-test',
         schemaVersion: 1,
-        defaultValue: {created: true},
       });
       expect(provider).toBeInstanceOf(LocalStorageProvider);
-      const result = provider.read();
-      expect(result.created).toBe(true);
     });
 
     it('should handle different configurations', () => {
       const provider1 = createLocalStorageProvider({
         name: 'config1',
         schemaVersion: 2,
-        defaultValue: 'default1',
       });
       const provider2 = createLocalStorageProvider({
         name: 'config2',
         schemaVersion: 1,
-        defaultValue: {key: 'default2'},
       });
-      expect(provider1.read()).toBe('default1');
-      expect(provider2.read().key).toBe('default2');
+      expect(provider1.read()).toBe(null);
+      expect(provider2.read()).toBe(null);
     });
   });
 });

--- a/packages/local-storage/src/type.ts
+++ b/packages/local-storage/src/type.ts
@@ -1,7 +1,7 @@
 import type {} from '@alwatr/nano-build';
 import type {} from '@alwatr/type-helper';
 
-export interface StorageMeta {
+export interface LocalStorageProviderConfig {
   /**
    * The unique name for the storage item.
    */
@@ -12,11 +12,4 @@ export interface StorageMeta {
    * starting from 1 and incrementing by 1 for each new version.
    */
   schemaVersion: number;
-}
-
-export interface LocalStorageProviderConfig<T extends JsonValue> extends StorageMeta {
-  /**
-   * The default value to use if no value is stored.
-   */
-  defaultValue: T;
 }

--- a/packages/local-storage/src/type.ts
+++ b/packages/local-storage/src/type.ts
@@ -1,6 +1,9 @@
 import type {} from '@alwatr/nano-build';
 import type {} from '@alwatr/type-helper';
 
+/**
+ * Configuration options for a local storage provider.
+ */
 export interface LocalStorageProviderConfig {
   /**
    * The unique name for the storage item.
@@ -8,8 +11,8 @@ export interface LocalStorageProviderConfig {
   name: string;
 
   /**
-   * The data structure version.
-   * starting from 1 and incrementing by 1 for each new version.
+   * The version of the data structure.
+   * Start from 1 for production, 0 for development mode, and increment by 1 for each new data schema change.
    */
   schemaVersion: number;
 }


### PR DESCRIPTION
Simplify the LocalStorageProvider configuration by removing the defaultValue property and updating related documentation and tests. This change introduces a breaking change in the API.