### PR TITLE
Rename Noop type and enhance DirectiveBase cleanup management

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,5 +70,8 @@
     "tsbuildinfo",
     "typeof",
     "cyrb53"
+  ],
+  "github-actions.workflows.pinned.workflows": [
+    ".github/workflows/publish-npm.yml"
   ]
 }

--- a/packages/synapse/src/directiveClass.ts
+++ b/packages/synapse/src/directiveClass.ts
@@ -141,9 +141,9 @@ export abstract class DirectiveBase {
 
     // Execute all registered cleanup tasks
     if (this.cleanupTaskList_.length > 0) {
-      for (const onDestroy of this.cleanupTaskList_) {
+      for (const task of this.cleanupTaskList_) {
         try {
-          onDestroy();
+          task();
         }
         catch (err) {
           this.logger_.error('destroy_', 'error_in_destroy_callback', err);

--- a/packages/synapse/src/directiveClass.ts
+++ b/packages/synapse/src/directiveClass.ts
@@ -49,6 +49,11 @@ export abstract class DirectiveBase {
   protected readonly element_: HTMLElement;
 
   /**
+   * A list of callback functions to be executed when the directive is destroyed.
+   */
+  private readonly cleanupTaskList_: NoopFunction[] = [];
+
+  /**
    * Initializes the directive. This constructor is called by the Synapse bootstrap process and should not be
    * overridden in subclasses.
    *
@@ -106,6 +111,25 @@ export abstract class DirectiveBase {
   }
 
   /**
+   * Registers a task to be executed when the directive is destroyed.
+   * Follows the `on[Event]` pattern, similar to `onClick`.
+   * Useful for cleaning up resources, such as unsubscribing from signals or removing global event listeners.
+   *
+   * @param task The cleanup task to register.
+   *
+   * @example
+   * ```ts
+   * this.onDestroy(
+   *   signal.subscribe(() => this.log('signal changed')).unsubscribe
+   * );
+   * ```
+   */
+  protected onDestroy(task: Func): void {
+    this.logger_.logMethod?.('onDestroy');
+    this.cleanupTaskList_.push(task);
+  }
+
+  /**
    * Cleans up the directive's resources.
    *
    * This method removes the element from the DOM and nullifies the internal reference to it,
@@ -114,6 +138,21 @@ export abstract class DirectiveBase {
    */
   protected destroy_(): Awaitable<void> {
     this.logger_.logMethod?.('destroy_');
+
+    // Execute all registered cleanup tasks
+    if (this.cleanupTaskList_.length > 0) {
+      for (const onDestroy of this.cleanupTaskList_) {
+        try {
+          onDestroy();
+        }
+        catch (err) {
+          this.logger_.error('destroy_', 'error_in_destroy_callback', err);
+        }
+      }
+
+      this.cleanupTaskList_.length = 0; // clear the list after executing all tasks
+    }
+
     this.element_.remove();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this as any).element_ = null;

--- a/packages/synapse/src/directiveClass.ts
+++ b/packages/synapse/src/directiveClass.ts
@@ -124,7 +124,7 @@ export abstract class DirectiveBase {
    * );
    * ```
    */
-  protected onDestroy(task: Func): void {
+  protected onDestroy(task: NoopFunction): void {
     this.logger_.logMethod?.('onDestroy');
     this.cleanupTaskList_.push(task);
   }

--- a/packages/type-helper/types.d.ts
+++ b/packages/type-helper/types.d.ts
@@ -49,7 +49,7 @@ declare global {
   type VoidFunction = Func<any[], void>;
 
   /** Alias for a no-op function with no arguments. */
-  type Noop = () => void;
+  type NoopFunction = () => void;
 
   /**
    * Removes the first parameter from a function type.


### PR DESCRIPTION
## Description

Renamed the `Noop` type to `NoopFunction` for clarity. Added a cleanup task management feature to `DirectiveBase` for improved resource management, allowing tasks to be registered for execution upon directive destruction. Additionally, introduced a pinned workflow for publishing the NPM package.

