### PR TITLE
Update test framework to Bun and improve CI scripts

### DIFF
--- a/.github/workflows/build-lint.yaml
+++ b/.github/workflows/build-lint.yaml
@@ -51,5 +51,5 @@ jobs:
       - name: 🚀 Run ESLint
         run: bun run lint
 
-      - name: 🚀 Run Jest
-        run: bun run test
+      - name: 🚀 Run Tests
+        run: bun test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,5 +59,8 @@
   ],
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@lerna-lite/publish": "^4.11.5",
         "@lerna-lite/run": "^4.11.5",
         "@lerna-lite/version": "^4.11.5",
+        "bun-types": "^1.3.10",
         "conventional-changelog-conventionalcommits": "^9.3.0",
         "conventional-commits-filter": "^5.0.0",
         "typescript": "^5.9.3",
@@ -19,7 +20,7 @@
     },
     "packages/async-queue": {
       "name": "@alwatr/async-queue",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "dependencies": {
         "@alwatr/flatomise": "workspace:*",
       },
@@ -33,7 +34,7 @@
     },
     "packages/cyrb53": {
       "name": "@alwatr/cyrb53",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -44,7 +45,7 @@
     },
     "packages/debounce": {
       "name": "@alwatr/debounce",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -56,7 +57,7 @@
     },
     "packages/dedupe": {
       "name": "@alwatr/dedupe",
-      "version": "5.5.30",
+      "version": "5.5.31",
       "dependencies": {
         "@alwatr/global-this": "workspace:*",
         "@alwatr/has-own": "workspace:*",
@@ -71,7 +72,7 @@
     },
     "packages/deep-clone": {
       "name": "@alwatr/deep-clone",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -81,7 +82,7 @@
     },
     "packages/delay": {
       "name": "@alwatr/delay",
-      "version": "6.0.20",
+      "version": "6.0.21",
       "dependencies": {
         "@alwatr/global-this": "workspace:*",
         "@alwatr/parse-duration": "workspace:*",
@@ -97,7 +98,7 @@
     },
     "packages/djb2-hash": {
       "name": "@alwatr/djb2-hash",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -107,7 +108,7 @@
     },
     "packages/env": {
       "name": "@alwatr/env",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "dependencies": {
         "@alwatr/platform-info": "workspace:*",
       },
@@ -122,7 +123,7 @@
     },
     "packages/exit-hook": {
       "name": "@alwatr/exit-hook",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -133,7 +134,7 @@
     },
     "packages/fetch": {
       "name": "@alwatr/fetch",
-      "version": "7.1.4",
+      "version": "7.1.5",
       "dependencies": {
         "@alwatr/delay": "workspace:*",
         "@alwatr/global-this": "workspace:*",
@@ -152,7 +153,7 @@
     },
     "packages/flat-string": {
       "name": "@alwatr/flat-string",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -162,7 +163,7 @@
     },
     "packages/flatomise": {
       "name": "@alwatr/flatomise",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -173,7 +174,7 @@
     },
     "packages/global-this": {
       "name": "@alwatr/global-this",
-      "version": "5.6.9",
+      "version": "5.6.10",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -185,7 +186,7 @@
     },
     "packages/has-own": {
       "name": "@alwatr/has-own",
-      "version": "5.6.7",
+      "version": "5.6.8",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -195,7 +196,7 @@
     },
     "packages/hash-string": {
       "name": "@alwatr/hash-string",
-      "version": "5.2.28",
+      "version": "5.2.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -205,7 +206,7 @@
     },
     "packages/http-primer": {
       "name": "@alwatr/http-primer",
-      "version": "6.0.20",
+      "version": "6.0.21",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -216,7 +217,7 @@
     },
     "packages/iranian-national-code-validator": {
       "name": "@alwatr/iranian-national-code-validator",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -227,7 +228,7 @@
     },
     "packages/is-number": {
       "name": "@alwatr/is-number",
-      "version": "5.7.25",
+      "version": "5.7.26",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -237,7 +238,7 @@
     },
     "packages/json2csv": {
       "name": "@alwatr/json2csv",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -248,7 +249,7 @@
     },
     "packages/local-storage": {
       "name": "@alwatr/local-storage",
-      "version": "7.0.8",
+      "version": "7.0.9",
       "dependencies": {
         "@alwatr/logger": "workspace:*",
       },
@@ -262,7 +263,7 @@
     },
     "packages/logger": {
       "name": "@alwatr/logger",
-      "version": "6.0.17",
+      "version": "6.0.18",
       "dependencies": {
         "@alwatr/global-this": "workspace:*",
         "@alwatr/platform-info": "workspace:*",
@@ -277,7 +278,7 @@
     },
     "packages/nano-build": {
       "name": "@alwatr/nano-build",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "bin": "./cli.cjs",
       "dependencies": {
         "esbuild": "^0.27.4",
@@ -293,7 +294,7 @@
     },
     "packages/nanolib": {
       "name": "@alwatr/nanolib",
-      "version": "7.3.6",
+      "version": "7.3.7",
       "bin": {
         "nano-build": "./nano-build.cjs",
       },
@@ -337,7 +338,7 @@
     },
     "packages/node-fs": {
       "name": "@alwatr/node-fs",
-      "version": "5.5.31",
+      "version": "5.5.32",
       "dependencies": {
         "@alwatr/async-queue": "workspace:*",
         "@alwatr/flat-string": "workspace:*",
@@ -354,7 +355,7 @@
     },
     "packages/package-tracer": {
       "name": "@alwatr/package-tracer",
-      "version": "5.5.27",
+      "version": "5.5.28",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -365,7 +366,7 @@
     },
     "packages/parse-duration": {
       "name": "@alwatr/parse-duration",
-      "version": "5.5.29",
+      "version": "5.5.30",
       "dependencies": {
         "@alwatr/is-number": "workspace:*",
       },
@@ -378,7 +379,7 @@
     },
     "packages/platform-info": {
       "name": "@alwatr/platform-info",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -407,7 +408,7 @@
     },
     "packages/random": {
       "name": "@alwatr/random",
-      "version": "5.1.29",
+      "version": "5.1.30",
       "dependencies": {
         "@alwatr/global-this": "workspace:*",
       },
@@ -420,7 +421,7 @@
     },
     "packages/render-state": {
       "name": "@alwatr/render-state",
-      "version": "5.5.31",
+      "version": "5.5.32",
       "dependencies": {
         "@alwatr/logger": "workspace:*",
       },
@@ -433,7 +434,7 @@
     },
     "packages/resolve-url": {
       "name": "@alwatr/resolve-url",
-      "version": "5.5.31",
+      "version": "5.5.32",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -444,7 +445,7 @@
     },
     "packages/session-storage": {
       "name": "@alwatr/session-storage",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@alwatr/logger": "workspace:*",
       },
@@ -458,7 +459,7 @@
     },
     "packages/synapse": {
       "name": "@alwatr/synapse",
-      "version": "1.3.6",
+      "version": "1.4.0",
       "dependencies": {
         "@alwatr/delay": "workspace:*",
         "@alwatr/logger": "workspace:*",
@@ -477,7 +478,7 @@
     },
     "packages/type-helper": {
       "name": "@alwatr/type-helper",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "devDependencies": {
         "@alwatr/prettier-config": "workspace:*",
         "typescript": "^5.9.3",
@@ -485,7 +486,7 @@
     },
     "packages/unicode-digits": {
       "name": "@alwatr/unicode-digits",
-      "version": "5.5.28",
+      "version": "5.5.29",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/prettier-config": "workspace:*",
@@ -496,7 +497,7 @@
     },
     "packages/yarn-upgrade": {
       "name": "@alwatr/yarn-upgrade",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "bin": {
         "upd": "./dist/main.cjs",
       },
@@ -790,6 +791,8 @@
     "bin-links": ["bin-links@6.0.0", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w=="],
 
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "byte-size": ["byte-size@9.0.1", "", { "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@lerna-lite/publish": "^4.11.5",
     "@lerna-lite/run": "^4.11.5",
     "@lerna-lite/version": "^4.11.5",
+    "bun-types": "^1.3.10",
     "conventional-changelog-conventionalcommits": "^9.3.0",
     "conventional-commits-filter": "^5.0.0",
     "typescript": "^5.9.3"
@@ -39,7 +40,7 @@
     "rl": "bun run pull && bun run clean && bun run build && bun run lint && bun run test && bun run release",
     "rlt": "bun run release --dry-run",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "lerna run --parallel watch"
   },

--- a/packages/async-queue/package.json
+++ b/packages/async-queue/package.json
@@ -75,7 +75,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/cyrb53/src/main.test.js
+++ b/packages/cyrb53/src/main.test.js
@@ -1,5 +1,5 @@
 import {cyrb53} from '@alwatr/cyrb53';
-import {describe, it, expect} from '@jest/globals';
+import {describe, it, expect} from 'bun:test';
 
 describe('cyrb53', () => {
   it('should generate a numeric hash for a string input', () => {

--- a/packages/debounce/src/debounce.test.js
+++ b/packages/debounce/src/debounce.test.js
@@ -1,10 +1,8 @@
-import {describe, beforeEach, afterEach, it, expect, jest} from '@jest/globals';
-import {createDebouncer} from '@alwatr/debounce';
+import { describe, beforeEach, afterEach, it, expect, jest } from 'bun:test';
+import { createDebouncer } from '@alwatr/debounce';
 
 describe('Debouncer', () => {
-  /**
-   * @type {import("jest-mock").Mock<import("jest-mock").UnknownFunction>}
-   */
+  /** @type {import('bun:test').Mock<(...args: unknown[]) => void>} */
   let mockFunc;
   /**
    * @type {import("@alwatr/debounce").Debouncer<typeof mockFunc>}
@@ -201,7 +199,7 @@ describe('Debouncer', () => {
     let context;
 
     beforeEach(() => {
-      context = {value: 'test'};
+      context = { value: 'test' };
       mockFunc = jest.fn(function () {
         this.value = 'changed';
       });
@@ -309,7 +307,7 @@ describe('Debouncer', () => {
       expect(mockFunc).toHaveBeenCalledTimes(1); // Should not call again
     });
   });
-  
+
   it('should execute after delay for trailing debounce', () => {
     debouncer = createDebouncer({
       func: mockFunc,

--- a/packages/djb2-hash/package.json
+++ b/packages/djb2-hash/package.json
@@ -65,7 +65,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -68,7 +68,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -77,7 +77,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/fetch/src/main.test.js
+++ b/packages/fetch/src/main.test.js
@@ -1,15 +1,21 @@
-import {describe, beforeEach, it, expect, jest} from '@jest/globals';
+import {describe, beforeEach, it, expect, jest} from 'bun:test';
 import {fetch, FetchError} from '@alwatr/fetch';
 
 // Mock global fetch
 const mockFetch = jest.fn();
+// @ts-expect-error type mismatch for global fetch
 global.fetch = mockFetch;
 
 // Mock global navigator for offline tests
+// @ts-expect-error type mismatch for global navigator
 global.navigator = {onLine: true};
 
 // Helper to create mock Response
+/**
+ * @param {unknown} data
+ */
 function createMockResponse(data, options = {}) {
+// @ts-expect-error type mismatch for data
   const {status = 200, statusText = 'OK', headers = {}} = options;
   return {
     ok: status >= 200 && status < 300,
@@ -27,6 +33,7 @@ function createMockResponse(data, options = {}) {
 describe('@alwatr/fetch', () => {
   beforeEach(() => {
     mockFetch.mockClear();
+    // @ts-expect-error 'onLine' is a read-only property
     global.navigator.onLine = true;
   });
 
@@ -39,9 +46,9 @@ describe('@alwatr/fetch', () => {
 
       expect(error).toBeNull();
       expect(response).toBeDefined();
-      expect(response.ok).toBe(true);
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toEqual(mockData);
+      expect(response?.ok).toBe(true);
+      expect(response?.status).toBe(200);
+      expect(response?.json()).resolves.toEqual(mockData);
     });
 
     it('should handle query parameters correctly', async () => {
@@ -111,9 +118,9 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('http_error');
-      expect(error.response.status).toBe(404);
-      expect(error.data).toEqual(errorData);
+      expect(error?.reason).toBe('http_error');
+      expect(error?.response?.status).toBe(404);
+      expect(error?.data).toEqual(errorData);
     });
 
     it('should return [null, FetchError] for 500 server error', async () => {
@@ -126,8 +133,8 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('http_error');
-      expect(error.response.status).toBe(500);
+      expect(error?.reason).toBe('http_error');
+      expect(error?.response?.status).toBe(500);
     });
 
     it('should parse non-JSON error response as text', async () => {
@@ -146,7 +153,7 @@ describe('@alwatr/fetch', () => {
       const [response, error] = await fetch('https://api.example.com/bad');
 
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.data).toBe('Plain text error message');
+      expect(error?.data).toBe('Plain text error message');
     });
   });
 
@@ -158,8 +165,8 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('network_error');
-      expect(error.message).toBe('Network request failed');
+      expect(error?.reason).toBe('network_error');
+      expect(error?.message).toBe('Network request failed');
     });
 
     it('should return [null, FetchError] for aborted request', async () => {
@@ -171,7 +178,7 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('aborted');
+      expect(error?.reason).toBe('aborted');
     });
 
     it('should handle unknown errors', async () => {
@@ -181,7 +188,7 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('unknown_error');
+      expect(error?.reason).toBe('unknown_error');
     });
   });
 
@@ -202,7 +209,7 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('timeout');
+      expect(error?.reason).toBe('timeout');
       clearTimeout(timeoutId);
     });
 
@@ -241,7 +248,7 @@ describe('@alwatr/fetch', () => {
       });
 
       expect(error).toBeNull();
-      expect(response.ok).toBe(true);
+      expect(response?.ok).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
@@ -268,7 +275,7 @@ describe('@alwatr/fetch', () => {
       });
 
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('http_error');
+      expect(error?.reason).toBe('http_error');
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -284,11 +291,12 @@ describe('@alwatr/fetch', () => {
 
       expect(response).toBeNull();
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.reason).toBe('http_error');
+      expect(error?.reason).toBe('http_error');
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it('should not retry when offline', async () => {
+      // @ts-expect-error 'onLine' is a read-only property
       global.navigator.onLine = false;
       const errorResponse = createMockResponse({}, {status: 500});
       errorResponse.text = jest.fn().mockResolvedValue('');
@@ -318,7 +326,7 @@ describe('@alwatr/fetch', () => {
       expect(results).toHaveLength(3);
       results.forEach(([response, error]) => {
         expect(error).toBeNull();
-        expect(response.ok).toBe(true);
+        expect(response?.ok).toBe(true);
       });
     });
 
@@ -376,7 +384,7 @@ describe('@alwatr/fetch', () => {
       const [response, error] = await fetch('https://api.example.com/empty', {retry: 0});
 
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.data).toBeUndefined();
+      expect(error?.data).toBeUndefined();
     });
 
     it('should handle malformed JSON in error response', async () => {
@@ -395,7 +403,7 @@ describe('@alwatr/fetch', () => {
       const [response, error] = await fetch('https://api.example.com/malformed', {retry: 0});
 
       expect(error).toBeInstanceOf(FetchError);
-      expect(error.data).toBe('{invalid json');
+      expect(error?.data).toBe('{invalid json');
     });
 
     it('should respect custom method', async () => {

--- a/packages/hash-string/package.json
+++ b/packages/hash-string/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/iranian-national-code-validator/package.json
+++ b/packages/iranian-national-code-validator/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/is-number/package.json
+++ b/packages/is-number/package.json
@@ -82,7 +82,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/json2csv/src/main.test.js
+++ b/packages/json2csv/src/main.test.js
@@ -1,5 +1,5 @@
 import {jsonToCsv} from '@alwatr/json2csv';
-import {describe, it, expect} from '@jest/globals';
+import {describe, it, expect} from 'bun:test';
 
 describe('jsonToCsv', () => {
   const testData = [

--- a/packages/local-storage/src/main.test.js
+++ b/packages/local-storage/src/main.test.js
@@ -1,24 +1,42 @@
-import {describe, beforeEach, afterEach, it, expect, jest} from '@jest/globals';
-import {createLocalStorageProvider, LocalStorageProvider} from '@alwatr/local-storage';
+import { describe, beforeEach, afterEach, it, expect, jest } from 'bun:test';
+import { createLocalStorageProvider, LocalStorageProvider } from '@alwatr/local-storage';
+
+/**
+ * @typedef {object} MockLocalStorage
+ * @property {import('bun:test').Mock<(key: string) => string | null>} getItem
+ * @property {import('bun:test').Mock<(key: string, value: string) => void>} setItem
+ * @property {import('bun:test').Mock<(key: string) => void>} removeItem
+ */
+
+/**
+ * @returns {MockLocalStorage}
+ */
+function createMockLocalStorage() {
+  return {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  };
+}
 
 /**
  * @jest-environment jsdom
  */
 describe('LocalStorageProvider', () => {
-  /**
-   * @type {jest.Mocked<Pick<Storage, "getItem" | "setItem" | "removeItem">>}
-   */
+  /** @type {MockLocalStorage} */
   let mockLocalStorage;
 
+  /** @type {Storage | undefined} */
+  let originalLocalStorage;
+
   beforeEach(() => {
-    mockLocalStorage = {
-      getItem: jest.fn(),
-      setItem: jest.fn(),
-      removeItem: jest.fn(),
-    };
+    originalLocalStorage = globalThis.localStorage;
+    mockLocalStorage = createMockLocalStorage();
+
     Object.defineProperty(globalThis, 'localStorage', {
       value: mockLocalStorage,
       writable: true,
+      configurable: true,
     });
   });
 
@@ -28,14 +46,14 @@ describe('LocalStorageProvider', () => {
 
   describe('static getKey', () => {
     it('should generate the correct versioned key', () => {
-      const key = LocalStorageProvider.getKey({name: 'test', schemaVersion: 1});
+      const key = LocalStorageProvider.getKey({ name: 'test', schemaVersion: 1 });
       expect(key).toBe('test.v1');
     });
 
     it('should handle different names and versions', () => {
-      const key1 = LocalStorageProvider.getKey({name: 'user-settings', schemaVersion: 2});
+      const key1 = LocalStorageProvider.getKey({ name: 'user-settings', schemaVersion: 2 });
       expect(key1).toBe('user-settings.v2');
-      const key2 = LocalStorageProvider.getKey({name: 'form-data', schemaVersion: 5});
+      const key2 = LocalStorageProvider.getKey({ name: 'form-data', schemaVersion: 5 });
       expect(key2).toBe('form-data.v5');
     });
   });
@@ -121,7 +139,7 @@ describe('LocalStorageProvider', () => {
         schemaVersion: 1,
       });
       const result = provider.read();
-      expect(result).toEqual({key: 'stored'});
+      expect(result).toEqual({ key: 'stored' });
     });
 
     it('should return null on invalid JSON', () => {
@@ -141,7 +159,7 @@ describe('LocalStorageProvider', () => {
         name: 'test',
         schemaVersion: 1,
       });
-      provider.write({key: 'newValue'});
+      provider.write({ key: 'newValue' });
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('test.v1', '{"key":"newValue"}');
     });
 
@@ -153,7 +171,7 @@ describe('LocalStorageProvider', () => {
         name: 'test',
         schemaVersion: 1,
       });
-      expect(() => provider.write({key: 'value'})).not.toThrow();
+      expect(() => provider.write({ key: 'value' })).not.toThrow();
     });
 
     it('should write different data types', () => {

--- a/packages/parse-duration/package.json
+++ b/packages/parse-duration/package.json
@@ -69,7 +69,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -79,7 +79,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/resolve-url/package.json
+++ b/packages/resolve-url/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",

--- a/packages/resolve-url/src/main.test.js
+++ b/packages/resolve-url/src/main.test.js
@@ -1,4 +1,4 @@
-import {describe, it, expect} from '@jest/globals';
+import {describe, it, expect} from 'bun:test';
 import {resolveUrl} from '@alwatr/resolve-url';
 
 describe('@alwatr/resolve-url - resolveUrl', () => {

--- a/packages/unicode-digits/package.json
+++ b/packages/unicode-digits/package.json
@@ -64,7 +64,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo",
     "d": "bun run build:es && bun --enable-source-maps --trace-warnings",
     "t": "bun run test",
-    "test": "echo test-skipped",
+    "test": "bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
     "watch:es": "bun run build:es --watch",


### PR DESCRIPTION
## Description

Switch the testing framework from Jest to Bun, updating test imports and assertions accordingly. Enhance CI scripts to streamline test execution and update package dependencies, including the addition of bun-types for improved type support. Adjust VSCode settings to set a default formatter for JavaScript.

