### PR TITLE
Fix context binding in Debouncer methods

### DIFF
--- a/packages/debounce/src/debounce.test.js
+++ b/packages/debounce/src/debounce.test.js
@@ -55,6 +55,13 @@ describe('Debouncer', () => {
       await fakeTimePassage(300);
       expect(mockFunc).not.toHaveBeenCalled();
     });
+
+    it('should keep the this context for trigger', async () => {
+      setTimeout(debouncer.trigger, 10, 'test');
+      await fakeTimePassage(310);
+      expect(mockFunc).toHaveBeenCalled();
+      expect(mockFunc).toHaveBeenCalledWith('test');
+    })
   });
 
   describe('Leading Debounce', () => {

--- a/packages/debounce/src/debounce.test.js
+++ b/packages/debounce/src/debounce.test.js
@@ -62,6 +62,13 @@ describe('Debouncer', () => {
       expect(mockFunc).toHaveBeenCalled();
       expect(mockFunc).toHaveBeenCalledWith('test');
     })
+
+    it('should keep the this context for cancel', async () => {
+      debouncer.trigger('test');
+      setTimeout(debouncer.cancel, 10);
+      await fakeTimePassage(310);
+      expect(mockFunc).not.toHaveBeenCalled();
+    });
   });
 
   describe('Leading Debounce', () => {

--- a/packages/debounce/src/debounce.ts
+++ b/packages/debounce/src/debounce.ts
@@ -38,6 +38,8 @@ export class Debouncer<F extends AnyFunc> {
   constructor(private readonly config__: DebouncerConfig<F>) {
     this.config__.trailing ??= true;
     this.flush = this.flush.bind(this);
+    this.trigger = this.trigger.bind(this);
+    this.cancel = this.cancel.bind(this);
   }
 
   /**


### PR DESCRIPTION
## Description

Bind the `trigger` and `cancel` methods in the Debouncer constructor to ensure the correct context is preserved. Add a test case to verify that the `this` context is maintained when invoking the `trigger` method.
